### PR TITLE
[npm release] separate autoversion bump and npm publish

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,12 +1,13 @@
 
-name: Auto tag and npm publish based on commit msg
-on: 
-  push:
+name: Auto tag based on commit msg
+on:   
+  pull_request: # only run on PR otherwise bot can't commit to protected branch
     branches:
-    - 'develop'
+    - develop
+
 jobs:
   build:
-    name: 'Bump version and npm publish'
+    name: 'Bump version and commit package.json'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout source code'
@@ -18,22 +19,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          patch-wording: '[Release]'
+          patch-wording: '[npm release]'
           tag-prefix:  'v'
-
-      - name: 'Show current version'
-        run: grep  '"version"' package.json
-
-      # Setup .npmrc file to publish to npm
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v2
-        with:
-          node-version: '16.x'
-          registry-url: 'https://registry.npmjs.org'
-          # Defaults to the user or organization that owns the workflow file
-          scope: '@openbeta'
-
-      - name: NPM publish
-        run: yarn install --no-progress && yarn lint && yarn test && yarn build && yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,31 @@
+
+name: npm publish based on commit msg
+on: 
+  push:
+    branches:
+    - 'develop'
+jobs:
+  build:
+    name: 'npm publish'
+    runs-on: ubuntu-latest
+    if: "startsWith(github.event.head_commit.message, '[npm release]')"
+    steps:
+      - name: 'Checkout source code'
+        uses: 'actions/checkout@v2'
+
+      - name: 'Show current version'
+        run: grep  '"version"' package.json
+
+      # Setup .npmrc file to publish to npm
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+          # Defaults to the user or organization that owns the workflow file
+          scope: '@openbeta'
+
+      - name: NPM publish
+        run: yarn install --no-progress && yarn lint && yarn test && yarn build && yarn publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openbeta/sandbag",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Rock climbing grades and conversions",
   "repository": "https://github.com/OpenBeta/sandbag.git",
   "module": "dist/sandbag.esm.js",


### PR DESCRIPTION
1.  Run version bump job on merge_request event and commit+push package.json changes to repo.  Due to `develop` branch protection, we can only run this action on merge_request
2. Run npm publish on push to develop branch with commit msg starts with [npm release].  