### PR TITLE
Add Testing for YDS Scores #11

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
     "ts-node": "^10.4.0",
     "ts-standard": "^11.0.0",
     "tsdx": "^0.14.1",
-    "typescript": "^4.5.5",
-    "win-node-env": "^0.6.1"
+    "typescript": "^4.5.5"
   },
   "engines": {
     "node": ">=14"
@@ -34,5 +33,8 @@
   "keywords": [
     "rock climbing",
     "climbing grades"
-  ]
+  ],
+  "optionalDependencies": {
+    "win-node-env": "^0.6.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "ts-node": "^10.4.0",
     "ts-standard": "^11.0.0",
     "tsdx": "^0.14.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "win-node-env": "^0.6.1"
   },
   "engines": {
     "node": ">=14"

--- a/src/__tests__/scales/yds.ts
+++ b/src/__tests__/scales/yds.ts
@@ -3,9 +3,83 @@ import { YosemiteDecimal } from '../../scales'
 describe('YosemiteDecimal', () => {
   describe('Get Score', () => {
     test('5.10a > 5.9', () => {
+      const lowGrade = YosemiteDecimal.getScore('5.9')
+      const highGrade = YosemiteDecimal.getScore('5.10a')
+      expect(highGrade[0]).toBeGreaterThan(lowGrade[1])
+    })
+
+    test('5.11a > 5.10+', () => {
+      const lowGrade = YosemiteDecimal.getScore('5.10+')
+      const highGrade = YosemiteDecimal.getScore('5.11a')
+      expect(highGrade[0]).toBeGreaterThan(lowGrade[1])
+    })
+
+    test('5.10b > 5.10a', () => {
       const lowGrade = YosemiteDecimal.getScore('5.10a')
-      const highGrade = YosemiteDecimal.getScore('5.9')
-      expect(lowGrade[0]).toBeGreaterThan(highGrade[1])
+      const highGrade = YosemiteDecimal.getScore('5.10b')
+      expect(highGrade[0]).toBeGreaterThan(lowGrade[1])
+    })
+
+    describe('invalid grade format', () => {
+      jest.spyOn(console, 'warn').mockImplementation()
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+      test('extra modifier', () => {
+        const invalidGrade = YosemiteDecimal.getScore('5.10a+')
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Unexpected grade format: 5.10a+')
+        )
+        expect(invalidGrade).toEqual(0)
+      })
+      test('missing 5. prefix', () => {
+        const invalidGrade = YosemiteDecimal.getScore('12a')
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Unexpected grade format: 12a')
+        )
+        expect(invalidGrade).toEqual(0)
+      })
+      test('not yds scale', () => {
+        const invalidGrade = YosemiteDecimal.getScore('v11')
+        expect(console.warn).toHaveBeenCalledWith(
+          expect.stringContaining('Unexpected grade format: v11')
+        )
+        expect(invalidGrade).toEqual(0)
+      })
+    })
+  })
+
+  describe('Is Type', () => {
+    test('grade without letter', () => {
+      expect(YosemiteDecimal.isType('5.9')).toBeTruthy()
+    })
+
+    test('grade with letter', () => {
+      expect(YosemiteDecimal.isType('5.11b')).toBeTruthy()
+    })
+
+    test('grade with letter uppercased', () => {
+      expect(YosemiteDecimal.isType('5.11B')).toBeTruthy()
+    })
+
+    test('grade plus modifier is accepted', () => {
+      expect(YosemiteDecimal.isType('5.12+')).toBeTruthy()
+      expect(YosemiteDecimal.isType('5.12-')).toBeTruthy()
+    })
+
+    test('grade with slash', () => {
+      expect(YosemiteDecimal.isType('5.10a/b')).toBeTruthy()
+    })
+
+    test('incorrect type', () => {
+      expect(YosemiteDecimal.isType('11+')).toBeFalsy()
+      expect(YosemiteDecimal.isType('v1')).toBeFalsy()
+      expect(YosemiteDecimal.isType('6a')).toBeFalsy()
+    })
+
+    test('has extra characters', () => {
+      expect(YosemiteDecimal.isType('5.12a+')).toBeFalsy()
+      expect(YosemiteDecimal.isType('5.12ab')).toBeFalsy()
     })
   })
 

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -5,7 +5,10 @@ import { Route } from '.'
 export type YdsType = 'yds'
 
 const REGEX_5_X = /(^5\.([0-9]|1[0-6]))()([+-])?$/i
+// Support 5.0 to 5.16 with + and -
 const REGEX_5_10_LETTER = /(^5\.(1[0-6]))([abcd])(\/[abcd])?$/i
+// Support 5.10x to 5.16x where x can be a,b,c,d. Allows for slash grade
+
 // const unicodeAlphabetStart = 96
 
 const isYds = (grade: string): RegExpMatchArray | null => grade.match(REGEX_5_X) ?? grade.match(REGEX_5_10_LETTER)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7865,6 +7865,11 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
+win-node-env@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/win-node-env/-/win-node-env-0.6.1.tgz#6684e136ec064aa4d47093899b13d4027ed2778b"
+  integrity sha512-oR+MLQ6jdvwqkLEkKBYxRvBOYbTlQV9dJKn8vLzjA4HCzcqdlCE6H1oOvA7lAdCgNXiOX0xfjl/Y47ZcZN6FDA==
+
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"


### PR DESCRIPTION
Fix for https://github.com/OpenBeta/sandbag/issues/11

- Improved the regex logic for the YDS grade scale to be more specific to only supporting. Used a slightly modified version of the regex found here for our use cases (https://openbeta.substack.com/p/climbing-grades-in-javascript). Thanks Viet :)
1. 5.0 to 5.16 with + and -
2. 5.10x to 5.16x where x can be a, b, c, or d. Allows for slash grade such as 5.10a/b

- Updated tests to yds.ts for un-normalized YDS scores. Displayed console warnings if the provided grade was not supported for YDS.
- Added win-node-env package for windows developers to get the tests working in a windows OS.