### PR TITLE
Fix auto release scripts to work based on [npm release] in title.

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,4 +1,3 @@
-
 name: Auto tag based on commit msg
 on:   
   pull_request: # only run on PR otherwise bot can't commit to protected branch
@@ -10,8 +9,7 @@ jobs:
     name: 'Bump version and commit package.json'
     runs-on: ubuntu-latest
     if: |
-      github.event.pull_request.merged == true &&
-      !contains(github.event.head_commit.message, 'skip ci')
+      github.event.pull_request.merged == true
     steps:
       - name: 'Checkout source code'
         uses: 'actions/checkout@v2'
@@ -24,3 +22,8 @@ jobs:
         with:
           patch-wording: '[npm release]'
           tag-prefix:  'v'
+          target-branch: 'develop'
+  call-npm-publish-workflow:
+    needs: build
+    if: "startsWith(github.event.pull_request.title, '[npm release]')"
+    uses: ./.github/workflows/npm-publish.yml

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,17 +1,16 @@
+name: npm publish
+on:
+  workflow_call:
 
-name: npm publish based on commit msg
-on: 
-  push:
-    branches:
-    - 'develop'
 jobs:
   build:
     name: 'npm publish'
     runs-on: ubuntu-latest
-    if: "startsWith(github.event.head_commit.message, '[npm release]')"
     steps:
       - name: 'Checkout source code'
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
+        with:
+          ref: develop
 
       - name: 'Show current version'
         run: grep  '"version"' package.json


### PR DESCRIPTION
A solution for #50

**The workflow for this solution is:**
1. A pull request gets merged into develop branch
2. The develop branch gets updated to the next version in its package.json, and the same version tag gets created in this repo.
3. If the title of the pull request starts with "[npm release]", then the latest version tag in this repo will be published to the npm repository.

**NOTE: this workflow is slightly different from the previous workflow.**
- It reduces the need to manually have to push the next version into the develop branch.
- A new version gets created every time a pull request is merged into the develop branch, regardless of having the "[npm release]". (Not sure if this was the same as before).
- The logic for when to publish the latest version tag to npm is based on the pull request title and not the latest commit. The reason for this is that a "pull request" workflow is surprisingly complicated to get the latest commit.
- The npm-publish yml file is now a dependent workflow, based on the outcome in the auto-tag yml file.