### PR TITLE
[npm publish] Add environment secrets to auto tag and npm publish workflows.

### DIFF
--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,4 +1,3 @@
-
 name: Auto tag based on commit msg
 on:   
   pull_request: # only run on PR otherwise bot can't commit to protected branch

--- a/.github/workflows/auto-version-bump.yml
+++ b/.github/workflows/auto-version-bump.yml
@@ -1,3 +1,4 @@
+
 name: Auto tag based on commit msg
 on:   
   pull_request: # only run on PR otherwise bot can't commit to protected branch
@@ -8,22 +9,26 @@ jobs:
   build:
     name: 'Bump version and commit package.json'
     runs-on: ubuntu-latest
+    environment: production
     if: |
       github.event.pull_request.merged == true
     steps:
       - name: 'Checkout source code'
-        uses: 'actions/checkout@v2'
+        uses: 'actions/checkout@v3'
+        with:
+          token: ${{ secrets.BOT_USER_TOKEN }}
+          ref: 'develop'
 
       - name:  'Automated Version Bump'
         id: version-bump
         uses:  'phips28/gh-action-bump-version@master'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.BOT_USER_TOKEN }}
         with:
           patch-wording: '[npm release]'
           tag-prefix:  'v'
           target-branch: 'develop'
   call-npm-publish-workflow:
     needs: build
-    if: "startsWith(github.event.pull_request.title, '[npm release]')"
+    if: "startsWith(github.event.pull_request.title, '[npm publish]')"
     uses: ./.github/workflows/npm-publish.yml

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-name: npm publish
+name: NPM publish
 on:
   workflow_call:
 
@@ -6,6 +6,7 @@ jobs:
   build:
     name: 'npm publish'
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: 'Checkout source code'
         uses: 'actions/checkout@v3'
@@ -27,4 +28,4 @@ jobs:
       - name: NPM publish
         run: yarn install --no-progress && yarn lint && yarn test && yarn build && yarn publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH }}


### PR DESCRIPTION
The workflows have been updated with environment secrets.

1. The environment secret for the auto tag workflow should allow us to keep branch protection turned on, but allow this CLI action to push to the develop branch to update the version in the package.json.

2. The environment secret for the npm publish workflow is an update to where we store the npm token as a secret.

NOTE: I updated the npm publish workflow to respect **"[npm publish]"** moving forward. This will need to be at the start of the PR title in order for you to publish the latest version tag in the repo as a new release in npm.

NOTE: I only tested this out in my local forked repo, so further testing should happen to verify everything is working as expected in this repo.