### PR TITLE
GradeBands / GradeScales logic from openbeta-graphql to @openbeta/sandbag

### DIFF
--- a/src/GradeBands.ts
+++ b/src/GradeBands.ts
@@ -1,0 +1,59 @@
+// import { getScale, getScoreForSort } from './GradeParser'
+// import { getAvgScore, GradeScalesTypes } from './GradeScale'
+
+export const GradeBands = {
+  UNKNOWN: 'unknown',
+  BEGINNER: 'beginner',
+  INTERMEDIATE: 'intermediate',
+  ADVANCED: 'advanced',
+  EXPERT: 'expert'
+} as const
+
+type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
+
+/**
+ *
+ * @param score universal grade score
+ * @param distribution GradeBandTypes to corresponding scores
+ * @returns GradeBandType for passed in score
+ */
+const scoreToBand = (score: number, distribution: Record<Exclude<GradeBandTypes, 'unknown'>, number>): string => {
+  const gradeBands = Object.keys(distribution).sort((a, b) => distribution[b] - distribution[a])
+  const gradeBand = gradeBands.find(gradeBand => distribution[gradeBand] <= score)
+  if (gradeBand === undefined) {
+    return GradeBands.UNKNOWN
+  }
+  return gradeBand
+}
+
+/**
+ *
+ * @param score universal grade score
+ * @returns GradeBandType for passed in score based on routes
+ */
+export const routeScoreToBand = (score: number): string => {
+  const distribution = {
+    [GradeBands.UNKNOWN]: -1,
+    [GradeBands.BEGINNER]: 0,
+    [GradeBands.INTERMEDIATE]: 54,
+    [GradeBands.ADVANCED]: 67.5,
+    [GradeBands.EXPERT]: 82.5
+  }
+  return scoreToBand(score, distribution)
+}
+
+/**
+ *
+ * @param score universal grade score
+ * @returns GradeBandType for passed in score based on bouldering
+ */
+export const boulderScoreToBand = (score: number): string => {
+  const distribution = {
+    [GradeBands.UNKNOWN]: -1,
+    [GradeBands.BEGINNER]: 0,
+    [GradeBands.INTERMEDIATE]: 50,
+    [GradeBands.ADVANCED]: 60,
+    [GradeBands.EXPERT]: 72
+  }
+  return scoreToBand(score, distribution)
+}

--- a/src/GradeBands.ts
+++ b/src/GradeBands.ts
@@ -1,6 +1,3 @@
-// import { getScale, getScoreForSort } from './GradeParser'
-// import { getAvgScore, GradeScalesTypes } from './GradeScale'
-
 export const GradeBands = {
   UNKNOWN: 'unknown',
   BEGINNER: 'beginner',
@@ -9,7 +6,7 @@ export const GradeBands = {
   EXPERT: 'expert'
 } as const
 
-type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
+export type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
 
 /**
  *

--- a/src/GradeBands.ts
+++ b/src/GradeBands.ts
@@ -14,12 +14,9 @@ export type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
  * @param distribution GradeBandTypes to corresponding scores
  * @returns GradeBandType for passed in score
  */
-const scoreToBand = (score: number, distribution: Record<Exclude<GradeBandTypes, 'unknown'>, number>): string => {
-  const gradeBands = Object.keys(distribution).sort((a, b) => distribution[b] - distribution[a])
-  const gradeBand = gradeBands.find(gradeBand => distribution[gradeBand] <= score)
-  if (gradeBand === undefined) {
-    return GradeBands.UNKNOWN
-  }
+const scoreToBand = (score: number, distribution: Record<GradeBandTypes, number>): GradeBandTypes => {
+  const gradeBands = Object.keys(distribution).sort((a, b) => distribution[b] - distribution[a]) as GradeBandTypes[]
+  const gradeBand: GradeBandTypes = gradeBands.find((gradeBand: GradeBandTypes) => distribution[gradeBand] <= score) ?? GradeBands.UNKNOWN
   return gradeBand
 }
 
@@ -28,7 +25,7 @@ const scoreToBand = (score: number, distribution: Record<Exclude<GradeBandTypes,
  * @param score universal grade score
  * @returns GradeBandType for passed in score based on routes
  */
-export const routeScoreToBand = (score: number): string => {
+export const routeScoreToBand = (score: number): GradeBandTypes => {
   const distribution = {
     [GradeBands.UNKNOWN]: -1,
     [GradeBands.BEGINNER]: 0,
@@ -44,7 +41,7 @@ export const routeScoreToBand = (score: number): string => {
  * @param score universal grade score
  * @returns GradeBandType for passed in score based on bouldering
  */
-export const boulderScoreToBand = (score: number): string => {
+export const boulderScoreToBand = (score: number): GradeBandTypes => {
   const distribution = {
     [GradeBands.UNKNOWN]: -1,
     [GradeBands.BEGINNER]: 0,

--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -15,7 +15,7 @@ export const getScale = (gradeScaleType: GradeScalesTypes): GradeScale | null =>
 }
 
 /**
- *
+ * @deprecated Replace with individual grade scale's getScore
  * @param grade grade based on grade scale type
  * @param gradeScaleType grade scale type
  * @returns  the score range, allows us to show the range of overlap for other grading systems
@@ -29,6 +29,7 @@ export const getScore = (grade: string, gradeScaleType: GradeScalesTypes): numbe
 }
 
 /**
+ * @deprecated Replace with individual grade scale's getScore
  * @param grade grade based on grade scale type
  * @param gradeScaleType grade scale type
  * @returns the average score of the grade for sorting across different scales

--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -1,12 +1,5 @@
 import GradeScale, { GradeScales, GradeScalesTypes, Tuple } from './GradeScale'
-import { VScale, YosemiteDecimal, Font, French } from './scales'
-
-const scales: Record<typeof GradeScales[keyof typeof GradeScales], GradeScale | null> = {
-  [GradeScales.VSCALE]: VScale,
-  [GradeScales.YDS]: YosemiteDecimal,
-  [GradeScales.FONT]: Font,
-  [GradeScales.FRENCH]: French
-}
+import { scales } from './scales'
 
 /**
  *
@@ -69,7 +62,7 @@ export const convertGrade = (
     )
     return ''
   }
-  const toScore = getScore(fromGrade, fromGradeScaleType)
+  const toScore = fromScale.getScore(fromGrade)
   return toScale.getGrade(toScore)
 }
 
@@ -79,77 +72,4 @@ export const isVScale = (grade: string): boolean => {
     return false
   }
   return scale.isType(grade)
-}
-
-export const GradeBands = {
-  UNKNOWN: 'unknown',
-  BEGINNER: 'beginner',
-  INTERMEDIATE: 'intermediate',
-  ADVANCED: 'advanced',
-  EXPERT: 'expert'
-} as const
-
-type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
-
-/**
- * Convert grade to band
- * @param grade grade based on grade scale type
- * @param gradeScaleType grade scale type
- * @returns GradeBand
- */
-
-export const getGradeBand = (grade: string, gradeScaleType: GradeScalesTypes): string => {
-  const score = getScoreForSort(grade, gradeScaleType)
-  const scale = getScale(gradeScaleType)
-  if (scale === null) {
-    return GradeBands.UNKNOWN
-  }
-  return scale.getGradeBand(score)
-}
-
-/**
- *
- * @param score universal grade score
- * @param distribution GradeBandTypes to corresponding scores
- * @returns GradeBandType for passed in score
- */
-const scoreToBand = (score: number, distribution: Record<Exclude<GradeBandTypes, 'unknown'>, number>): string => {
-  const gradeBands = Object.keys(distribution).sort((a, b) => distribution[b] - distribution[a])
-  const gradeBand = gradeBands.find(gradeBand => distribution[gradeBand] <= score)
-  if (gradeBand === undefined) {
-    return GradeBands.UNKNOWN
-  }
-  return gradeBand
-}
-
-/**
- *
- * @param score universal grade score
- * @returns GradeBandType for passed in score based on routes
- */
-export const routeScoreToBand = (score: number): string => {
-  const distribution = {
-    [GradeBands.UNKNOWN]: -1,
-    [GradeBands.BEGINNER]: 0,
-    [GradeBands.INTERMEDIATE]: 54,
-    [GradeBands.ADVANCED]: 67.5,
-    [GradeBands.EXPERT]: 82.5
-  }
-  return scoreToBand(score, distribution)
-}
-
-/**
- *
- * @param score universal grade score
- * @returns GradeBandType for passed in score based on bouldering
- */
-export const boulderScoreToBand = (score: number): string => {
-  const distribution = {
-    [GradeBands.UNKNOWN]: -1,
-    [GradeBands.BEGINNER]: 0,
-    [GradeBands.INTERMEDIATE]: 50,
-    [GradeBands.ADVANCED]: 60,
-    [GradeBands.EXPERT]: 72
-  }
-  return scoreToBand(score, distribution)
 }

--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -2,10 +2,10 @@ import GradeScale, { GradeScales, GradeScalesTypes, Tuple } from './GradeScale'
 import { VScale, YosemiteDecimal, Font, French } from './scales'
 
 const scales: Record<typeof GradeScales[keyof typeof GradeScales], GradeScale | null> = {
-  [GradeScales.VScale]: VScale,
-  [GradeScales.Yds]: YosemiteDecimal,
-  [GradeScales.Font]: Font,
-  [GradeScales.French]: French
+  [GradeScales.VSCALE]: VScale,
+  [GradeScales.YDS]: YosemiteDecimal,
+  [GradeScales.FONT]: Font,
+  [GradeScales.FRENCH]: French
 }
 
 /**
@@ -74,7 +74,7 @@ export const convertGrade = (
 }
 
 export const isVScale = (grade: string): boolean => {
-  const scale = scales[GradeScales.VScale]
+  const scale = scales[GradeScales.VSCALE]
   if (scale == null) {
     return false
   }

--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -1,7 +1,7 @@
-import GradeScale, { GradeScales, Tuple } from './GradeScale'
+import GradeScale, { GradeScales, GradeScalesTypes, Tuple } from './GradeScale'
 import { VScale, YosemiteDecimal, Font, French } from './scales'
 
-const scales: Record<GradeScales, GradeScale | null> = {
+const scales: Record<typeof GradeScales[keyof typeof GradeScales], GradeScale | null> = {
   [GradeScales.VScale]: VScale,
   [GradeScales.Yds]: YosemiteDecimal,
   [GradeScales.Font]: Font,
@@ -10,66 +10,66 @@ const scales: Record<GradeScales, GradeScale | null> = {
 
 /**
  *
- * @param scaleName
+ * @param gradeScaleType grade scale type
  * @returns grade scale of provided grade scale name
  */
-export const getScale = (scaleName: GradeScales): GradeScale | null => {
-  const scale = scales[scaleName]
+export const getScale = (gradeScaleType: GradeScalesTypes): GradeScale | null => {
+  const scale = scales[gradeScaleType]
   if (scale === null) {
-    console.warn(`Scale: ${scaleName} isn't currently supported`)
+    console.warn(`Scale: ${gradeScaleType} isn't currently supported`)
   }
   return scale
 }
 
 /**
  *
- * @param grade
- * @param scaleName
+ * @param grade grade based on grade scale type
+ * @param gradeScaleType grade scale type
  * @returns  the score range, allows us to show the range of overlap for other grading systems
  */
-export const getScore = (grade: string, scaleName: GradeScales): number | Tuple => {
-  const scale = getScale(scaleName)
+export const getScore = (grade: string, gradeScaleType: GradeScalesTypes): number | Tuple => {
+  const scale = getScale(gradeScaleType)
   if (scale === null) {
-    return 0
+    return -1
   }
   return scale.getScore(grade)
 }
 
 /**
- * @param grade
- * @param type
+ * @param grade grade based on grade scale type
+ * @param gradeScaleType grade scale type
  * @returns the average score of the grade for sorting across different scales
  */
-export const getScoreForSort = (grade: string, type: GradeScales): number => {
-  const range = getScore(grade, type)
+export const getScoreForSort = (grade: string, gradeScaleType: GradeScalesTypes): number => {
+  const range = getScore(grade, gradeScaleType)
   return typeof range === 'number' ? range : (range[1] + range[0]) / 2
 }
 
 /**
  *
- * @param fromGrade
- * @param fromType
- * @param toType
+ * @param fromGrade grade based on grade scale type
+ * @param fromGradeScaleType grade scale type to convert grade from
+ * @param toGradeScaleType grade scale type to convert grade to
  * @returns A scale's grade converted to a different scale's grade
  */
 export const convertGrade = (
   fromGrade: string,
-  fromType: GradeScales,
-  toType: GradeScales
+  fromGradeScaleType: GradeScalesTypes,
+  toGradeScaleType: GradeScalesTypes
 ): string => {
-  const fromScale = getScale(fromType)
-  const toScale = getScale(toType)
+  const fromScale = getScale(fromGradeScaleType)
+  const toScale = getScale(toGradeScaleType)
   if (fromScale === null || toScale === null) {
     return ''
   }
-  const checkScaleToConvert: boolean = fromScale.allowableConversionType.includes(toType)
+  const checkScaleToConvert: boolean = fromScale.allowableConversionType.includes(toGradeScaleType)
   if (!checkScaleToConvert) {
     console.warn(
       `Scale: ${fromScale.displayName} doesn't support converting to Scale: ${toScale.displayName}`
     )
     return ''
   }
-  const toScore = getScore(fromGrade, fromType)
+  const toScore = getScore(fromGrade, fromGradeScaleType)
   return toScale.getGrade(toScore)
 }
 
@@ -79,4 +79,77 @@ export const isVScale = (grade: string): boolean => {
     return false
   }
   return scale.isType(grade)
+}
+
+export const GradeBands = {
+  UNKNOWN: 'unknown',
+  BEGINNER: 'beginner',
+  INTERMEDIATE: 'intermediate',
+  ADVANCED: 'advanced',
+  EXPERT: 'expert'
+} as const
+
+type GradeBandTypes = typeof GradeBands[keyof typeof GradeBands]
+
+/**
+ * Convert grade to band
+ * @param grade grade based on grade scale type
+ * @param gradeScaleType grade scale type
+ * @returns GradeBand
+ */
+
+export const getGradeBand = (grade: string, gradeScaleType: GradeScalesTypes): string => {
+  const score = getScoreForSort(grade, gradeScaleType)
+  const scale = getScale(gradeScaleType)
+  if (scale === null) {
+    return GradeBands.UNKNOWN
+  }
+  return scale.getGradeBand(score)
+}
+
+/**
+ *
+ * @param score universal grade score
+ * @param distribution GradeBandTypes to corresponding scores
+ * @returns GradeBandType for passed in score
+ */
+const scoreToBand = (score: number, distribution: Record<Exclude<GradeBandTypes, 'unknown'>, number>): string => {
+  const gradeBands = Object.keys(distribution).sort((a, b) => distribution[b] - distribution[a])
+  const gradeBand = gradeBands.find(gradeBand => distribution[gradeBand] <= score)
+  if (gradeBand === undefined) {
+    return GradeBands.UNKNOWN
+  }
+  return gradeBand
+}
+
+/**
+ *
+ * @param score universal grade score
+ * @returns GradeBandType for passed in score based on routes
+ */
+export const routeScoreToBand = (score: number): string => {
+  const distribution = {
+    [GradeBands.UNKNOWN]: -1,
+    [GradeBands.BEGINNER]: 0,
+    [GradeBands.INTERMEDIATE]: 54,
+    [GradeBands.ADVANCED]: 67.5,
+    [GradeBands.EXPERT]: 82.5
+  }
+  return scoreToBand(score, distribution)
+}
+
+/**
+ *
+ * @param score universal grade score
+ * @returns GradeBandType for passed in score based on bouldering
+ */
+export const boulderScoreToBand = (score: number): string => {
+  const distribution = {
+    [GradeBands.UNKNOWN]: -1,
+    [GradeBands.BEGINNER]: 0,
+    [GradeBands.INTERMEDIATE]: 50,
+    [GradeBands.ADVANCED]: 60,
+    [GradeBands.EXPERT]: 72
+  }
+  return scoreToBand(score, distribution)
 }

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -4,7 +4,7 @@ export default interface GradeScale {
   isType: (grade: string) => boolean
   getScore: (grade: string) => number | Tuple
   getGrade: (score: number | Tuple) => string
-  getGradeBand: (score: number) => string
+  getGradeBand: (grade: string) => string
   displayName: string
   name: GradeScalesTypes
   offset: number

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -1,10 +1,12 @@
+import { GradeBandTypes } from './GradeBands'
+
 export type Tuple = [number, number]
 
 export default interface GradeScale {
   isType: (grade: string) => boolean
   getScore: (grade: string) => number | Tuple
   getGrade: (score: number | Tuple) => string
-  getGradeBand: (grade: string) => string
+  getGradeBand: (grade: string) => GradeBandTypes
   displayName: string
   name: GradeScalesTypes
   offset: number

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -12,10 +12,10 @@ export default interface GradeScale {
 }
 
 export const GradeScales = {
-  VScale: 'vscale',
-  Yds: 'yds',
-  Font: 'font',
-  French: 'french'
+  VSCALE: 'vscale',
+  YDS: 'yds',
+  FONT: 'font',
+  FRENCH: 'french'
 } as const
 
 export type GradeScalesTypes = typeof GradeScales[keyof typeof GradeScales]

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -4,17 +4,21 @@ export default interface GradeScale {
   isType: (grade: string) => boolean
   getScore: (grade: string) => number | Tuple
   getGrade: (score: number | Tuple) => string
+  getGradeBand: (score: number) => string
   displayName: string
-  name: string
+  name: GradeScalesTypes
   offset: number
-  allowableConversionType: GradeScales[]
+  allowableConversionType: GradeScalesTypes[]
 }
-export enum GradeScales {
-  VScale ='vscale',
-  Yds = 'yds',
-  Font = 'font',
-  French = 'french'
-}
+
+export const GradeScales = {
+  VScale: 'vscale',
+  Yds: 'yds',
+  Font: 'font',
+  French: 'french'
+} as const
+
+export type GradeScalesTypes = typeof GradeScales[keyof typeof GradeScales]
 
 export const findScoreRange = (compareFn, list): number | Tuple => {
   const scores = list.filter(compareFn)

--- a/src/__tests__/GradeBands.ts
+++ b/src/__tests__/GradeBands.ts
@@ -1,0 +1,25 @@
+// import { GradeBands } from '../GradeBands'
+// import { GradeScales } from '../GradeScale'
+
+test.todo('todo')
+// describe('GradeBands', () => {
+//   test('returns grade band based on grade and grade scale type', () => {
+//     expect(getGradeBand('v0', GradeScales.VSCALE)).toEqual(GradeBands.BEGINNER)
+//     expect(getGradeBand('v2', GradeScales.VSCALE)).toEqual(GradeBands.INTERMEDIATE)
+//     expect(getGradeBand('v5', GradeScales.VSCALE)).toEqual(GradeBands.ADVANCED)
+//     expect(getGradeBand('v7', GradeScales.VSCALE)).toEqual(GradeBands.EXPERT)
+
+//     expect(getGradeBand('5.9', GradeScales.YDS)).toEqual(GradeBands.INTERMEDIATE)
+//     expect(getGradeBand('7a', GradeScales.FONT)).toEqual(GradeBands.EXPERT)
+//     expect(getGradeBand('7a', GradeScales.FRENCH)).toEqual(GradeBands.ADVANCED)
+//   })
+//   test('returns unknown gradeband if grade and grade scale type are mismatched', () => {
+//     jest.spyOn(console, 'warn').mockImplementation()
+//     expect(getGradeBand('5.9', GradeScales.VSCALE)).toEqual(GradeBands.UNKNOWN)
+//     expect(console.warn).toHaveBeenCalledWith(
+//       expect.stringContaining(
+//         'Unexpected grade format: 5.9'
+//       )
+//     )
+//   })
+// })

--- a/src/__tests__/GradeBands.ts
+++ b/src/__tests__/GradeBands.ts
@@ -1,25 +1,18 @@
-// import { GradeBands } from '../GradeBands'
-// import { GradeScales } from '../GradeScale'
+import { boulderScoreToBand, GradeBands, routeScoreToBand } from '../GradeBands'
 
-test.todo('todo')
-// describe('GradeBands', () => {
-//   test('returns grade band based on grade and grade scale type', () => {
-//     expect(getGradeBand('v0', GradeScales.VSCALE)).toEqual(GradeBands.BEGINNER)
-//     expect(getGradeBand('v2', GradeScales.VSCALE)).toEqual(GradeBands.INTERMEDIATE)
-//     expect(getGradeBand('v5', GradeScales.VSCALE)).toEqual(GradeBands.ADVANCED)
-//     expect(getGradeBand('v7', GradeScales.VSCALE)).toEqual(GradeBands.EXPERT)
-
-//     expect(getGradeBand('5.9', GradeScales.YDS)).toEqual(GradeBands.INTERMEDIATE)
-//     expect(getGradeBand('7a', GradeScales.FONT)).toEqual(GradeBands.EXPERT)
-//     expect(getGradeBand('7a', GradeScales.FRENCH)).toEqual(GradeBands.ADVANCED)
-//   })
-//   test('returns unknown gradeband if grade and grade scale type are mismatched', () => {
-//     jest.spyOn(console, 'warn').mockImplementation()
-//     expect(getGradeBand('5.9', GradeScales.VSCALE)).toEqual(GradeBands.UNKNOWN)
-//     expect(console.warn).toHaveBeenCalledWith(
-//       expect.stringContaining(
-//         'Unexpected grade format: 5.9'
-//       )
-//     )
-//   })
-// })
+describe('GradeBands', () => {
+  test('returns grade bands based on scores for a route distribution', () => {
+    expect(routeScoreToBand(-1)).toEqual(GradeBands.UNKNOWN)
+    expect(routeScoreToBand(0)).toEqual(GradeBands.BEGINNER)
+    expect(routeScoreToBand(54)).toEqual(GradeBands.INTERMEDIATE)
+    expect(routeScoreToBand(67.5)).toEqual(GradeBands.ADVANCED)
+    expect(routeScoreToBand(82.5)).toEqual(GradeBands.EXPERT)
+  })
+  test('returns grade bands based on scores for a bouldering distribution', () => {
+    expect(boulderScoreToBand(-1)).toEqual(GradeBands.UNKNOWN)
+    expect(boulderScoreToBand(0)).toEqual(GradeBands.BEGINNER)
+    expect(boulderScoreToBand(50)).toEqual(GradeBands.INTERMEDIATE)
+    expect(boulderScoreToBand(60)).toEqual(GradeBands.ADVANCED)
+    expect(boulderScoreToBand(72)).toEqual(GradeBands.EXPERT)
+  })
+})

--- a/src/__tests__/GradeParser.ts
+++ b/src/__tests__/GradeParser.ts
@@ -11,33 +11,33 @@ describe('Grade Scales', () => {
   })
   describe('YDS', () => {
     test('5.9 > 5.8', () => {
-      expect(getScoreForSort('5.9', GradeScales.Yds)).toBeGreaterThan(
-        getScoreForSort('5.8', GradeScales.Yds)
+      expect(getScoreForSort('5.9', GradeScales.YDS)).toBeGreaterThan(
+        getScoreForSort('5.8', GradeScales.YDS)
       )
     })
 
     test('5.10b > 5.10a', () => {
-      expect(getScoreForSort('5.10b', GradeScales.Yds)).toBeGreaterThan(
-        getScoreForSort('5.10a', GradeScales.Yds)
+      expect(getScoreForSort('5.10b', GradeScales.YDS)).toBeGreaterThan(
+        getScoreForSort('5.10a', GradeScales.YDS)
       )
     })
 
     test('5.11a > 5.10+', () => {
-      expect(getScoreForSort('5.11a', GradeScales.Yds)).toBeGreaterThan(
-        getScoreForSort('5.10+', GradeScales.Yds)
+      expect(getScoreForSort('5.11a', GradeScales.YDS)).toBeGreaterThan(
+        getScoreForSort('5.10+', GradeScales.YDS)
       )
     })
 
     test('returns a GradeScale given the name', () => {
-      expect(getScale(GradeScales.Yds)).toEqual(YosemiteDecimal)
+      expect(getScale(GradeScales.YDS)).toEqual(YosemiteDecimal)
     })
 
-    test('convert YDS to French', () => {
-      expect(convertGrade('5.11a', GradeScales.Yds, GradeScales.French)).toEqual('6b+/6c')
+    test('convert YDS to FRENCH', () => {
+      expect(convertGrade('5.11a', GradeScales.YDS, GradeScales.FRENCH)).toEqual('6b+/6c')
     })
 
-    test('convert YDS to VScale is not allowed', () => {
-      expect(convertGrade('5.11a', GradeScales.Yds, GradeScales.VScale)).toEqual('')
+    test('convert YDS to VSCALE is not allowed', () => {
+      expect(convertGrade('5.11a', GradeScales.YDS, GradeScales.VSCALE)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "Scale: Yosemite Decimal System doesn't support converting to Scale: V Scale"
@@ -46,41 +46,41 @@ describe('Grade Scales', () => {
     })
   })
 
-  describe('V', () => {
+  describe('VSCALE', () => {
     test('v5 > V3', () => {
-      expect(getScoreForSort('v5', GradeScales.VScale)).toBeGreaterThan(
-        getScoreForSort('V3', GradeScales.VScale)
+      expect(getScoreForSort('v5', GradeScales.VSCALE)).toBeGreaterThan(
+        getScoreForSort('V3', GradeScales.VSCALE)
       )
     })
 
     test('v2-3 > V2', () => {
-      expect(getScoreForSort('v2-3', GradeScales.VScale)).toBeGreaterThan(
-        getScoreForSort('V2', GradeScales.VScale)
+      expect(getScoreForSort('v2-3', GradeScales.VSCALE)).toBeGreaterThan(
+        getScoreForSort('V2', GradeScales.VSCALE)
       )
     })
 
     test('v3 > V2-3', () => {
-      expect(getScoreForSort('v3', GradeScales.VScale)).toBeGreaterThan(
-        getScoreForSort('V2-3', GradeScales.VScale)
+      expect(getScoreForSort('v3', GradeScales.VSCALE)).toBeGreaterThan(
+        getScoreForSort('V2-3', GradeScales.VSCALE)
       )
     })
 
     test('v20+ > V20', () => {
-      expect(getScoreForSort('V20+', GradeScales.VScale)).toBeGreaterThan(
-        getScoreForSort('V20', GradeScales.VScale)
+      expect(getScoreForSort('V20+', GradeScales.VSCALE)).toBeGreaterThan(
+        getScoreForSort('V20', GradeScales.VSCALE)
       )
     })
 
     test('returns a GradeScale given the name', () => {
-      expect(getScale(GradeScales.VScale)).toEqual(VScale)
+      expect(getScale(GradeScales.VSCALE)).toEqual(VScale)
     })
 
-    test('convert VScale to Font', () => {
-      expect(convertGrade('v7', GradeScales.VScale, GradeScales.Font)).toEqual('7a+/7b')
+    test('convert VSCALE to FONT', () => {
+      expect(convertGrade('v7', GradeScales.VSCALE, GradeScales.FONT)).toEqual('7a+/7b')
     })
 
-    test('convert VScale to YDS is not allowed', () => {
-      expect(convertGrade('v5', GradeScales.VScale, GradeScales.Yds)).toEqual('')
+    test('convert VSCALE to YDS is not allowed', () => {
+      expect(convertGrade('v5', GradeScales.VSCALE, GradeScales.YDS)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "Scale: V Scale doesn't support converting to Scale: Yosemite Decimal System"
@@ -88,49 +88,49 @@ describe('Grade Scales', () => {
       )
     })
 
-    test('convert VScale to French is not allowed', () => {
-      expect(convertGrade('v5', GradeScales.VScale, GradeScales.French)).toEqual('')
+    test('convert VSCALE to FRENCH is not allowed', () => {
+      expect(convertGrade('v5', GradeScales.VSCALE, GradeScales.FRENCH)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining("Scale: V Scale doesn't support converting to Scale: French Scale")
       )
     })
   })
 
-  describe('Font', () => {
+  describe('FONT', () => {
     test('2a > 1a', () => {
-      expect(getScoreForSort('2a', GradeScales.Font)).toBeGreaterThan(
-        getScoreForSort('1a', GradeScales.Font)
+      expect(getScoreForSort('2a', GradeScales.FONT)).toBeGreaterThan(
+        getScoreForSort('1a', GradeScales.FONT)
       )
     })
 
     test('2a+ > 2a', () => {
-      expect(getScoreForSort('2a+', GradeScales.Font)).toBeGreaterThan(
-        getScoreForSort('2a', GradeScales.Font)
+      expect(getScoreForSort('2a+', GradeScales.FONT)).toBeGreaterThan(
+        getScoreForSort('2a', GradeScales.FONT)
       )
     })
 
     test('3a/3a+ > 3a', () => {
-      expect(getScoreForSort('3a/3a+', GradeScales.Font)).toBeGreaterThan(
-        getScoreForSort('3a', GradeScales.Font)
+      expect(getScoreForSort('3a/3a+', GradeScales.FONT)).toBeGreaterThan(
+        getScoreForSort('3a', GradeScales.FONT)
       )
     })
 
     test('4a > 3a+/4a', () => {
-      expect(getScoreForSort('4a', GradeScales.Font)).toBeGreaterThan(
-        getScoreForSort('3a+/4a', GradeScales.Font)
+      expect(getScoreForSort('4a', GradeScales.FONT)).toBeGreaterThan(
+        getScoreForSort('3a+/4a', GradeScales.FONT)
       )
     })
 
     test('returns a GradeScale given the name', () => {
-      expect(getScale(GradeScales.Font)).toEqual(Font)
+      expect(getScale(GradeScales.FONT)).toEqual(Font)
     })
 
-    test('convert Font to VScale', () => {
-      expect(convertGrade('3a', GradeScales.Font, GradeScales.VScale)).toEqual('VB+')
+    test('convert FONT to VSCALE', () => {
+      expect(convertGrade('3a', GradeScales.FONT, GradeScales.VSCALE)).toEqual('VB+')
     })
 
-    test('convert Font to YDS is not allowed', () => {
-      expect(convertGrade('3a', GradeScales.Font, GradeScales.Yds)).toEqual('')
+    test('convert FONT to YDS is not allowed', () => {
+      expect(convertGrade('3a', GradeScales.FONT, GradeScales.YDS)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "Scale: Fontainebleau doesn't support converting to Scale: Yosemite Decimal System"
@@ -138,8 +138,8 @@ describe('Grade Scales', () => {
       )
     })
 
-    test('convert Font to French is not allowed', () => {
-      expect(convertGrade('3a', GradeScales.Font, GradeScales.French)).toEqual('')
+    test('convert FONT to FRENCH is not allowed', () => {
+      expect(convertGrade('3a', GradeScales.FONT, GradeScales.FRENCH)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "Scale: Fontainebleau doesn't support converting to Scale: French Scale"
@@ -148,41 +148,41 @@ describe('Grade Scales', () => {
     })
   })
 
-  describe('French', () => {
+  describe('FRENCH', () => {
     test('2a > 1a', () => {
-      expect(getScoreForSort('2a', GradeScales.French)).toBeGreaterThan(
-        getScoreForSort('1a', GradeScales.French)
+      expect(getScoreForSort('2a', GradeScales.FRENCH)).toBeGreaterThan(
+        getScoreForSort('1a', GradeScales.FRENCH)
       )
     })
 
     test('2a+ > 2a', () => {
-      expect(getScoreForSort('2a+', GradeScales.French)).toBeGreaterThan(
-        getScoreForSort('2a', GradeScales.French)
+      expect(getScoreForSort('2a+', GradeScales.FRENCH)).toBeGreaterThan(
+        getScoreForSort('2a', GradeScales.FRENCH)
       )
     })
 
     test('3a/3a+ > 3a', () => {
-      expect(getScoreForSort('3a/3a+', GradeScales.French)).toBeGreaterThan(
-        getScoreForSort('3a', GradeScales.French)
+      expect(getScoreForSort('3a/3a+', GradeScales.FRENCH)).toBeGreaterThan(
+        getScoreForSort('3a', GradeScales.FRENCH)
       )
     })
 
     test('4a > 3a+/4a', () => {
-      expect(getScoreForSort('4a', GradeScales.French)).toBeGreaterThan(
-        getScoreForSort('3a+/4a', GradeScales.French)
+      expect(getScoreForSort('4a', GradeScales.FRENCH)).toBeGreaterThan(
+        getScoreForSort('3a+/4a', GradeScales.FRENCH)
       )
     })
 
     test('returns a GradeScale given the name', () => {
-      expect(getScale(GradeScales.French)).toEqual(French)
+      expect(getScale(GradeScales.FRENCH)).toEqual(French)
     })
 
-    test('convert French to YDS', () => {
-      expect(convertGrade('3a', GradeScales.French, GradeScales.Yds)).toEqual('5.3')
+    test('convert FRENCH to YDS', () => {
+      expect(convertGrade('3a', GradeScales.FRENCH, GradeScales.YDS)).toEqual('5.3')
     })
 
-    test('convert French to Font is not allowed', () => {
-      expect(convertGrade('3a', GradeScales.French, GradeScales.Font)).toEqual('')
+    test('convert FRENCH to FONT is not allowed', () => {
+      expect(convertGrade('3a', GradeScales.FRENCH, GradeScales.FONT)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           "Scale: French Scale doesn't support converting to Scale: Fontainebleau"
@@ -190,8 +190,8 @@ describe('Grade Scales', () => {
       )
     })
 
-    test('convert French to VScale is not allowed', () => {
-      expect(convertGrade('3a', GradeScales.French, GradeScales.VScale)).toEqual('')
+    test('convert FRENCH to VSCALE is not allowed', () => {
+      expect(convertGrade('3a', GradeScales.FRENCH, GradeScales.VSCALE)).toEqual('')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining("Scale: French Scale doesn't support converting to Scale: V Scale")
       )
@@ -201,16 +201,16 @@ describe('Grade Scales', () => {
 
 describe('GradeBands', () => {
   test('returns grade band based on grade and grade scale type', () => {
-    expect(getGradeBand('v0', GradeScales.VScale)).toEqual(GradeBands.BEGINNER)
-    expect(getGradeBand('v2', GradeScales.VScale)).toEqual(GradeBands.INTERMEDIATE)
-    expect(getGradeBand('v5', GradeScales.VScale)).toEqual(GradeBands.ADVANCED)
-    expect(getGradeBand('v7', GradeScales.VScale)).toEqual(GradeBands.EXPERT)
+    expect(getGradeBand('v0', GradeScales.VSCALE)).toEqual(GradeBands.BEGINNER)
+    expect(getGradeBand('v2', GradeScales.VSCALE)).toEqual(GradeBands.INTERMEDIATE)
+    expect(getGradeBand('v5', GradeScales.VSCALE)).toEqual(GradeBands.ADVANCED)
+    expect(getGradeBand('v7', GradeScales.VSCALE)).toEqual(GradeBands.EXPERT)
 
-    expect(getGradeBand('5.9', GradeScales.Yds)).toEqual(GradeBands.INTERMEDIATE)
-    expect(getGradeBand('7a', GradeScales.Font)).toEqual(GradeBands.EXPERT)
-    expect(getGradeBand('7a', GradeScales.French)).toEqual(GradeBands.ADVANCED)
+    expect(getGradeBand('5.9', GradeScales.YDS)).toEqual(GradeBands.INTERMEDIATE)
+    expect(getGradeBand('7a', GradeScales.FONT)).toEqual(GradeBands.EXPERT)
+    expect(getGradeBand('7a', GradeScales.FRENCH)).toEqual(GradeBands.ADVANCED)
   })
   test('returns unknown gradeband if grade and grade scale type are mismatched', () => {
-    expect(getGradeBand('5.9', GradeScales.VScale)).toEqual(GradeBands.UNKNOWN)
+    expect(getGradeBand('5.9', GradeScales.VSCALE)).toEqual(GradeBands.UNKNOWN)
   })
 })

--- a/src/__tests__/GradeParser.ts
+++ b/src/__tests__/GradeParser.ts
@@ -1,4 +1,4 @@
-import { getScoreForSort, convertGrade, getScale, getGradeBand, GradeBands } from '../GradeParser'
+import { getScoreForSort, convertGrade, getScale } from '../GradeParser'
 import { GradeScales } from '../GradeScale'
 import { VScale, Font, YosemiteDecimal, French } from '../scales'
 
@@ -196,21 +196,5 @@ describe('Grade Scales', () => {
         expect.stringContaining("Scale: French Scale doesn't support converting to Scale: V Scale")
       )
     })
-  })
-})
-
-describe('GradeBands', () => {
-  test('returns grade band based on grade and grade scale type', () => {
-    expect(getGradeBand('v0', GradeScales.VSCALE)).toEqual(GradeBands.BEGINNER)
-    expect(getGradeBand('v2', GradeScales.VSCALE)).toEqual(GradeBands.INTERMEDIATE)
-    expect(getGradeBand('v5', GradeScales.VSCALE)).toEqual(GradeBands.ADVANCED)
-    expect(getGradeBand('v7', GradeScales.VSCALE)).toEqual(GradeBands.EXPERT)
-
-    expect(getGradeBand('5.9', GradeScales.YDS)).toEqual(GradeBands.INTERMEDIATE)
-    expect(getGradeBand('7a', GradeScales.FONT)).toEqual(GradeBands.EXPERT)
-    expect(getGradeBand('7a', GradeScales.FRENCH)).toEqual(GradeBands.ADVANCED)
-  })
-  test('returns unknown gradeband if grade and grade scale type are mismatched', () => {
-    expect(getGradeBand('5.9', GradeScales.VSCALE)).toEqual(GradeBands.UNKNOWN)
   })
 })

--- a/src/__tests__/GradeParser.ts
+++ b/src/__tests__/GradeParser.ts
@@ -1,4 +1,4 @@
-import { getScoreForSort, convertGrade, getScale } from '../GradeParser'
+import { getScoreForSort, convertGrade, getScale, getGradeBand, GradeBands } from '../GradeParser'
 import { GradeScales } from '../GradeScale'
 import { VScale, Font, YosemiteDecimal, French } from '../scales'
 
@@ -196,5 +196,21 @@ describe('Grade Scales', () => {
         expect.stringContaining("Scale: French Scale doesn't support converting to Scale: V Scale")
       )
     })
+  })
+})
+
+describe('GradeBands', () => {
+  test('returns grade band based on grade and grade scale type', () => {
+    expect(getGradeBand('v0', GradeScales.VScale)).toEqual(GradeBands.BEGINNER)
+    expect(getGradeBand('v2', GradeScales.VScale)).toEqual(GradeBands.INTERMEDIATE)
+    expect(getGradeBand('v5', GradeScales.VScale)).toEqual(GradeBands.ADVANCED)
+    expect(getGradeBand('v7', GradeScales.VScale)).toEqual(GradeBands.EXPERT)
+
+    expect(getGradeBand('5.9', GradeScales.Yds)).toEqual(GradeBands.INTERMEDIATE)
+    expect(getGradeBand('7a', GradeScales.Font)).toEqual(GradeBands.EXPERT)
+    expect(getGradeBand('7a', GradeScales.French)).toEqual(GradeBands.ADVANCED)
+  })
+  test('returns unknown gradeband if grade and grade scale type are mismatched', () => {
+    expect(getGradeBand('5.9', GradeScales.VScale)).toEqual(GradeBands.UNKNOWN)
   })
 })

--- a/src/__tests__/scales/font.ts
+++ b/src/__tests__/scales/font.ts
@@ -1,4 +1,4 @@
-import { GradeBands } from '../../GradeParser'
+import { GradeBands } from '../../GradeBands'
 import { Font } from '../../scales'
 
 describe('Font', () => {
@@ -95,8 +95,8 @@ describe('Font', () => {
 
   describe('Get Grade Band', () => {
     test('gets Gradeband', () => {
-      expect(Font.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
-      expect(Font.getGradeBand(72)).toEqual(GradeBands.EXPERT)
+      expect(Font.getGradeBand('1a')).toEqual(GradeBands.BEGINNER)
+      expect(Font.getGradeBand('9c+')).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/font.ts
+++ b/src/__tests__/scales/font.ts
@@ -36,37 +36,30 @@ describe('Font', () => {
       })
       test('extra plus modifier', () => {
         const invalidGrade = Font.getScore('5a++')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 5a++')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a++ for grade scale font')
         expect(invalidGrade).toEqual(-1)
       })
       test('invalid minus modifier', () => {
         const invalidGrade = Font.getScore('5a-')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 5a-')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a- for grade scale font')
         expect(invalidGrade).toEqual(-1)
       })
       test('extra slash grade', () => {
         const invalidGrade = Font.getScore('5a/5a+/5b+')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 5a/5a+/5b+')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a/5a+/5b+ for grade scale font')
+
         expect(invalidGrade).toEqual(-1)
       })
       test('extra slash', () => {
         const invalidGrade = Font.getScore('5a/')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 5a/')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a/ for grade scale font')
+
         expect(invalidGrade).toEqual(-1)
       })
       test('not font scale', () => {
         const invalidGrade = Font.getScore('v11')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: v11')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: v11 for grade scale font')
+
         expect(invalidGrade).toEqual(-1)
       })
     })

--- a/src/__tests__/scales/font.ts
+++ b/src/__tests__/scales/font.ts
@@ -1,3 +1,4 @@
+import { GradeBands } from '../../GradeParser'
 import { Font } from '../../scales'
 
 describe('Font', () => {
@@ -38,35 +39,35 @@ describe('Font', () => {
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 5a++')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('invalid minus modifier', () => {
         const invalidGrade = Font.getScore('5a-')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 5a-')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('extra slash grade', () => {
         const invalidGrade = Font.getScore('5a/5a+/5b+')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 5a/5a+/5b+')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('extra slash', () => {
         const invalidGrade = Font.getScore('5a/')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 5a/')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('not font scale', () => {
         const invalidGrade = Font.getScore('v11')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: v11')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
     })
   })
@@ -89,6 +90,13 @@ describe('Font', () => {
       expect(Font.getGrade([0.5, 2])).toBe('1a/1a+')
       expect(Font.getGrade([8, 12])).toBe('1c/2a')
       expect(Font.getGrade([16, 17])).toBe('2b')
+    })
+  })
+
+  describe('Get Grade Band', () => {
+    test('gets Gradeband', () => {
+      expect(Font.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
+      expect(Font.getGradeBand(72)).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/french.ts
+++ b/src/__tests__/scales/french.ts
@@ -37,37 +37,27 @@ describe('French', () => {
     })
     test('extra plus modifier', () => {
       const invalidGrade = French.getScore('5a++')
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected grade format: 5a++')
-      )
+      expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a++ for grade scale french')
       expect(invalidGrade).toEqual(-1)
     })
     test('invalid minus modifier', () => {
       const invalidGrade = French.getScore('5a-')
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected grade format: 5a-')
-      )
+      expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a- for grade scale french')
       expect(invalidGrade).toEqual(-1)
     })
     test('extra slash grade', () => {
       const invalidGrade = French.getScore('5a/5a+/5b+')
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected grade format: 5a/5a+/5b+')
-      )
+      expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a/5a+/5b+ for grade scale french')
       expect(invalidGrade).toEqual(-1)
     })
     test('extra slash', () => {
       const invalidGrade = French.getScore('5a/')
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected grade format: 5a/')
-      )
+      expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5a/ for grade scale french')
       expect(invalidGrade).toEqual(-1)
     })
     test('not French scale', () => {
       const invalidGrade = French.getScore('v11')
-      expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('Unexpected grade format: v11')
-      )
+      expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: v11 for grade scale french')
       expect(invalidGrade).toEqual(-1)
     })
   })

--- a/src/__tests__/scales/french.ts
+++ b/src/__tests__/scales/french.ts
@@ -1,4 +1,4 @@
-import { GradeBands } from '../../GradeParser'
+import { GradeBands } from '../../GradeBands'
 import { French } from '../../scales'
 
 describe('French', () => {
@@ -95,8 +95,8 @@ describe('French', () => {
 
   describe('Get Grade Band', () => {
     test('gets Gradeband', () => {
-      expect(French.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
-      expect(French.getGradeBand(82.5)).toEqual(GradeBands.EXPERT)
+      expect(French.getGradeBand('1a')).toEqual(GradeBands.BEGINNER)
+      expect(French.getGradeBand('9c+')).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/french.ts
+++ b/src/__tests__/scales/french.ts
@@ -1,3 +1,4 @@
+import { GradeBands } from '../../GradeParser'
 import { French } from '../../scales'
 
 describe('French', () => {
@@ -39,56 +40,63 @@ describe('French', () => {
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected grade format: 5a++')
       )
-      expect(invalidGrade).toEqual(0)
+      expect(invalidGrade).toEqual(-1)
     })
     test('invalid minus modifier', () => {
       const invalidGrade = French.getScore('5a-')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected grade format: 5a-')
       )
-      expect(invalidGrade).toEqual(0)
+      expect(invalidGrade).toEqual(-1)
     })
     test('extra slash grade', () => {
       const invalidGrade = French.getScore('5a/5a+/5b+')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected grade format: 5a/5a+/5b+')
       )
-      expect(invalidGrade).toEqual(0)
+      expect(invalidGrade).toEqual(-1)
     })
     test('extra slash', () => {
       const invalidGrade = French.getScore('5a/')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected grade format: 5a/')
       )
-      expect(invalidGrade).toEqual(0)
+      expect(invalidGrade).toEqual(-1)
     })
     test('not French scale', () => {
       const invalidGrade = French.getScore('v11')
       expect(console.warn).toHaveBeenCalledWith(
         expect.stringContaining('Unexpected grade format: v11')
       )
-      expect(invalidGrade).toEqual(0)
+      expect(invalidGrade).toEqual(-1)
     })
   })
-})
 
-describe('Get Grade', () => {
-  test('bottom of range', () => {
-    expect(French.getGrade(0)).toBe('1a')
+  describe('Get Grade', () => {
+    test('bottom of range', () => {
+      expect(French.getGrade(0)).toBe('1a')
+    })
+
+    test('top of range', () => {
+      expect(French.getGrade(1000)).toBe('9c+')
+    })
+
+    test('single score provided', () => {
+      expect(French.getGrade(34)).toBe('3c+')
+      expect(French.getGrade(34.5)).toBe('3c+')
+      expect(French.getGrade(35)).toBe('3c+')
+    })
+    test('range of scores provided', () => {
+      expect(French.getGrade([0.5, 2])).toBe('1a/1a+')
+      expect(French.getGrade([8, 12])).toBe('1c/2a')
+      expect(French.getGrade([16, 17])).toBe('2b')
+    })
   })
 
-  test('top of range', () => {
-    expect(French.getGrade(1000)).toBe('9c+')
-  })
-
-  test('single score provided', () => {
-    expect(French.getGrade(34)).toBe('3c+')
-    expect(French.getGrade(34.5)).toBe('3c+')
-    expect(French.getGrade(35)).toBe('3c+')
-  })
-  test('range of scores provided', () => {
-    expect(French.getGrade([0.5, 2])).toBe('1a/1a+')
-    expect(French.getGrade([8, 12])).toBe('1c/2a')
-    expect(French.getGrade([16, 17])).toBe('2b')
+  describe('Get Grade Band', () => {
+    test('gets Gradeband', () => {
+      expect(French.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
+      expect(French.getGradeBand(82.5)).toEqual(GradeBands.EXPERT)
+    })
   })
 })

--- a/src/__tests__/scales/v.ts
+++ b/src/__tests__/scales/v.ts
@@ -1,4 +1,4 @@
-import { GradeBands } from '../../GradeParser'
+import { GradeBands } from '../../GradeBands'
 import { VScale } from '../../scales'
 
 describe('V', () => {
@@ -78,8 +78,8 @@ describe('V', () => {
 
   describe('Get Grade Band', () => {
     test('gets Gradeband', () => {
-      expect(VScale.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
-      expect(VScale.getGradeBand(72)).toEqual(GradeBands.EXPERT)
+      expect(VScale.getGradeBand('V0')).toEqual(GradeBands.BEGINNER)
+      expect(VScale.getGradeBand('V22')).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/v.ts
+++ b/src/__tests__/scales/v.ts
@@ -1,3 +1,4 @@
+import { GradeBands } from '../../GradeParser'
 import { VScale } from '../../scales'
 
 describe('V', () => {
@@ -72,6 +73,13 @@ describe('V', () => {
       expect(VScale.getGrade([51, 56])).toBe('V1-V2')
       expect(VScale.getGrade([77, 80])).toBe('V8-V9')
       expect(VScale.getGrade([66, 72])).toBe('V4-V6')
+    })
+  })
+
+  describe('Get Grade Band', () => {
+    test('gets Gradeband', () => {
+      expect(VScale.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
+      expect(VScale.getGradeBand(72)).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/yds.ts
+++ b/src/__tests__/scales/yds.ts
@@ -1,4 +1,4 @@
-import { GradeBands } from '../../GradeParser'
+import { GradeBands } from '../../GradeBands'
 import { YosemiteDecimal } from '../../scales'
 
 describe('YosemiteDecimal', () => {
@@ -114,8 +114,8 @@ describe('YosemiteDecimal', () => {
 
   describe('Get Grade Band', () => {
     test('gets Gradeband', () => {
-      expect(YosemiteDecimal.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
-      expect(YosemiteDecimal.getGradeBand(82.5)).toEqual(GradeBands.EXPERT)
+      expect(YosemiteDecimal.getGradeBand('5.8')).toEqual(GradeBands.BEGINNER)
+      expect(YosemiteDecimal.getGradeBand('5.15a')).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/yds.ts
+++ b/src/__tests__/scales/yds.ts
@@ -1,3 +1,4 @@
+import { GradeBands } from '../../GradeParser'
 import { YosemiteDecimal } from '../../scales'
 
 describe('YosemiteDecimal', () => {
@@ -35,21 +36,21 @@ describe('YosemiteDecimal', () => {
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 5.10a+')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('missing 5. prefix', () => {
         const invalidGrade = YosemiteDecimal.getScore('12a')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: 12a')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
       test('not yds scale', () => {
         const invalidGrade = YosemiteDecimal.getScore('v11')
         expect(console.warn).toHaveBeenCalledWith(
           expect.stringContaining('Unexpected grade format: v11')
         )
-        expect(invalidGrade).toEqual(0)
+        expect(invalidGrade).toEqual(-1)
       })
     })
   })
@@ -108,6 +109,13 @@ describe('YosemiteDecimal', () => {
       expect(YosemiteDecimal.getGrade([63, 65])).toBe('5.10b/c')
       expect(YosemiteDecimal.getGrade([56, 59])).toBe('5.9/5.10a')
       expect(YosemiteDecimal.getGrade([74, 75])).toBe('5.11d/5.12a')
+    })
+  })
+
+  describe('Get Grade Band', () => {
+    test('gets Gradeband', () => {
+      expect(YosemiteDecimal.getGradeBand(0)).toEqual(GradeBands.BEGINNER)
+      expect(YosemiteDecimal.getGradeBand(82.5)).toEqual(GradeBands.EXPERT)
     })
   })
 })

--- a/src/__tests__/scales/yds.ts
+++ b/src/__tests__/scales/yds.ts
@@ -33,23 +33,17 @@ describe('YosemiteDecimal', () => {
       })
       test('extra modifier', () => {
         const invalidGrade = YosemiteDecimal.getScore('5.10a+')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 5.10a+')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 5.10a+ for grade scale yds')
         expect(invalidGrade).toEqual(-1)
       })
       test('missing 5. prefix', () => {
         const invalidGrade = YosemiteDecimal.getScore('12a')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: 12a')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: 12a for grade scale yds')
         expect(invalidGrade).toEqual(-1)
       })
       test('not yds scale', () => {
         const invalidGrade = YosemiteDecimal.getScore('v11')
-        expect(console.warn).toHaveBeenCalledWith(
-          expect.stringContaining('Unexpected grade format: v11')
-        )
+        expect(console.warn).toHaveBeenCalledWith('Unexpected grade format: v11 for grade scale yds')
         expect(invalidGrade).toEqual(-1)
       })
     })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import { getScoreForGrade } from './vyds'
-import { getScore, getScoreForSort, isVScale, getGradeBand } from './GradeParser'
 import { GradeScales } from './GradeScale'
+import { getScore, getScoreForSort, isVScale } from './GradeParser'
 // Free Climbing Grades
 // YDS
 // French
@@ -90,4 +90,4 @@ export const bouldering = {
 
 }
 
-export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales, getGradeBand }
+export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 
 import { getScoreForGrade } from './vyds'
 import { GradeScales, GradeScalesTypes } from './GradeScale'
-import { getScore, getScoreForSort, isVScale } from './GradeParser'
+import { getScale, getScore, getScoreForSort, isVScale } from './GradeParser'
 import { GradeBands, GradeBandTypes } from './GradeBands'
 // Free Climbing Grades
 // YDS
@@ -91,4 +91,4 @@ export const bouldering = {
 
 }
 
-export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales, GradeScalesTypes, GradeBands, GradeBandTypes }
+export { getScoreForGrade, getScore, getScoreForSort, isVScale, getScale, GradeScales, GradeScalesTypes, GradeBands, GradeBandTypes }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 
 import { getScoreForGrade } from './vyds'
-import { GradeScales } from './GradeScale'
+import { GradeScales, GradeScalesTypes } from './GradeScale'
 import { getScore, getScoreForSort, isVScale } from './GradeParser'
+import { GradeBands, GradeBandTypes } from './GradeBands'
 // Free Climbing Grades
 // YDS
 // French
@@ -90,4 +91,4 @@ export const bouldering = {
 
 }
 
-export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales }
+export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales, GradeScalesTypes, GradeBands, GradeBandTypes }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 
 import { getScoreForGrade } from './vyds'
-import { getScore, getScoreForSort, isVScale } from './GradeParser'
+import { getScore, getScoreForSort, isVScale, getGradeBand } from './GradeParser'
 import { GradeScales } from './GradeScale'
 // Free Climbing Grades
 // YDS
@@ -90,4 +90,4 @@ export const bouldering = {
 
 }
 
-export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales }
+export { getScoreForGrade, getScore, getScoreForSort, isVScale, GradeScales, getGradeBand }

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -2,7 +2,7 @@ import boulder from '../data/boulder.json'
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 
 import { Boulder } from '.'
-export type FontScaleType = 'fontScale'
+import { boulderScoreToBand } from '../GradeParser'
 
 const fontGradeRegex = /^([1-9][a-c][+]?){1}(?:(\/)([1-9][a-c][+]?))?$/i
 // Supports 1a -> 9c+, slash grades i.e. 5a/5a+ or 6a+/6b
@@ -25,7 +25,7 @@ const FontScale: GradeScale = {
     const parse = isFont(grade)
     if (parse == null) {
       console.warn(`Unexpected grade format: ${grade}`)
-      return 0
+      return -1
     }
     const [wholeMatch, basicGrade, slash] = parse
     const basicScore = findScoreRange((b: Boulder) => {
@@ -62,7 +62,8 @@ const FontScale: GradeScale = {
     const high: string = boulder[validateScore(score[1])].font
     if (low === high) return low
     return `${low}/${high}`
-  }
+  },
+  getGradeBand: (score: number): string => boulderScoreToBand(score)
 }
 
 export default FontScale

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -12,9 +12,9 @@ const isFont = (grade: string): RegExpMatchArray | null => grade.match(fontGrade
 
 const FontScale: GradeScale = {
   displayName: 'Fontainebleau',
-  name: GradeScales.Font,
+  name: GradeScales.FONT,
   offset: 1000,
-  allowableConversionType: [GradeScales.VScale],
+  allowableConversionType: [GradeScales.VSCALE],
   isType: (grade: string): boolean => {
     if (isFont(grade) === null) {
       return false

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -48,7 +48,7 @@ const FontScale: GradeScale = {
 const getScore = (grade: string): number | Tuple => {
   const parse = isFont(grade)
   if (parse == null) {
-    console.warn(`Unexpected grade format: ${grade}`)
+    console.warn(`Unexpected grade format: ${grade} for grade scale font`)
     return -1
   }
   const [wholeMatch, basicGrade, slash] = parse

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -2,7 +2,7 @@ import boulder from '../data/boulder.json'
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 
 import { Boulder } from '.'
-import { boulderScoreToBand } from '../GradeBands'
+import { boulderScoreToBand, GradeBandTypes } from '../GradeBands'
 
 const fontGradeRegex = /^([1-9][a-c][+]?){1}(?:(\/)([1-9][a-c][+]?))?$/i
 // Supports 1a -> 9c+, slash grades i.e. 5a/5a+ or 6a+/6b
@@ -39,7 +39,7 @@ const FontScale: GradeScale = {
     if (low === high) return low
     return `${low}/${high}`
   },
-  getGradeBand: (grade: string): string => {
+  getGradeBand: (grade: string): GradeBandTypes => {
     const score = getScore(grade)
     return boulderScoreToBand(getAvgScore(score))
   }

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -11,9 +11,9 @@ const isFrench = (grade: string): RegExpMatchArray | null => grade.match(frenchG
 
 const FrenchScale: GradeScale = {
   displayName: 'French Scale',
-  name: GradeScales.French,
+  name: GradeScales.FRENCH,
   offset: 1000,
-  allowableConversionType: [GradeScales.Yds],
+  allowableConversionType: [GradeScales.YDS],
   isType: (grade: string): boolean => {
     if (isFrench(grade) === null) {
       return false

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -1,6 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
+import { routeScoreToBand } from '../GradeParser'
 
 const frenchGradeRegex = /^([1-9][a-c][+]?){1}(?:(\/)([1-9][a-c][+]?))?$/i
 // Supports 1a -> 9c+, slash grades i.e. 5a/5a+ or 6a+/6b
@@ -23,7 +24,7 @@ const FrenchScale: GradeScale = {
     const parse = isFrench(grade)
     if (parse == null) {
       console.warn(`Unexpected grade format: ${grade}`)
-      return 0
+      return -1
     }
     const [wholeMatch, basicGrade, slash] = parse
     const basicScore = findScoreRange((r: Route) => {
@@ -60,7 +61,9 @@ const FrenchScale: GradeScale = {
     const high: string = routes[validateScore(score[1])].french
     if (low === high) return low
     return `${low}/${high}`
-  }
+  },
+  getGradeBand: (score: number): string => routeScoreToBand(score)
+
 }
 
 export default FrenchScale

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
-import { routeScoreToBand } from '../GradeBands'
+import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
 
 const frenchGradeRegex = /^([1-9][a-c][+]?){1}(?:(\/)([1-9][a-c][+]?))?$/i
 // Supports 1a -> 9c+, slash grades i.e. 5a/5a+ or 6a+/6b
@@ -38,7 +38,7 @@ const FrenchScale: GradeScale = {
     if (low === high) return low
     return `${low}/${high}`
   },
-  getGradeBand: (grade: string): string => {
+  getGradeBand: (grade: string): GradeBandTypes => {
     const score = getScore(grade)
     return routeScoreToBand(getAvgScore(score))
   }

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
-import { routeScoreToBand } from '../GradeParser'
+import { routeScoreToBand } from '../GradeBands'
 
 const frenchGradeRegex = /^([1-9][a-c][+]?){1}(?:(\/)([1-9][a-c][+]?))?$/i
 // Supports 1a -> 9c+, slash grades i.e. 5a/5a+ or 6a+/6b
@@ -21,31 +21,7 @@ const FrenchScale: GradeScale = {
     return true
   },
   getScore: (grade: string): number | Tuple => {
-    const parse = isFrench(grade)
-    if (parse == null) {
-      console.warn(`Unexpected grade format: ${grade}`)
-      return -1
-    }
-    const [wholeMatch, basicGrade, slash] = parse
-    const basicScore = findScoreRange((r: Route) => {
-      return r.french === basicGrade
-    }, routes)
-
-    if (wholeMatch !== basicGrade) {
-      // 5a/5a+
-      let otherGrade
-      if (slash !== null) {
-        otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[1]) + 1
-      }
-      if (otherGrade !== undefined) {
-        const nextGrade = findScoreRange(
-          (r: Route) => r.french.toLowerCase() === routes[otherGrade].french.toLowerCase(),
-          routes
-        )
-        return [getAvgScore(basicScore), getAvgScore(nextGrade)].sort((a, b) => a - b) as Tuple
-      }
-    }
-    return basicScore
+    return getScore(grade)
   },
   getGrade: (score: number | Tuple): string => {
     const validateScore = (score: number): number => {
@@ -62,8 +38,38 @@ const FrenchScale: GradeScale = {
     if (low === high) return low
     return `${low}/${high}`
   },
-  getGradeBand: (score: number): string => routeScoreToBand(score)
+  getGradeBand: (grade: string): string => {
+    const score = getScore(grade)
+    return routeScoreToBand(getAvgScore(score))
+  }
+}
 
+const getScore = (grade: string): number | Tuple => {
+  const parse = isFrench(grade)
+  if (parse == null) {
+    console.warn(`Unexpected grade format: ${grade}`)
+    return -1
+  }
+  const [wholeMatch, basicGrade, slash] = parse
+  const basicScore = findScoreRange((r: Route) => {
+    return r.french === basicGrade
+  }, routes)
+
+  if (wholeMatch !== basicGrade) {
+    // 5a/5a+
+    let otherGrade
+    if (slash !== null) {
+      otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[1]) + 1
+    }
+    if (otherGrade !== undefined) {
+      const nextGrade = findScoreRange(
+        (r: Route) => r.french.toLowerCase() === routes[otherGrade].french.toLowerCase(),
+        routes
+      )
+      return [getAvgScore(basicScore), getAvgScore(nextGrade)].sort((a, b) => a - b) as Tuple
+    }
+  }
+  return basicScore
 }
 
 export default FrenchScale

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -47,7 +47,7 @@ const FrenchScale: GradeScale = {
 const getScore = (grade: string): number | Tuple => {
   const parse = isFrench(grade)
   if (parse == null) {
-    console.warn(`Unexpected grade format: ${grade}`)
+    console.warn(`Unexpected grade format: ${grade} for grade scale french`)
     return -1
   }
   const [wholeMatch, basicGrade, slash] = parse

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -2,6 +2,7 @@ import VScale from './v'
 import YosemiteDecimal from './yds'
 import Font from './font'
 import French from './french'
+import GradeScale, { GradeScales } from '../GradeScale'
 export { VScale, Font, YosemiteDecimal, French }
 
 export interface Boulder {
@@ -16,4 +17,11 @@ export interface Route {
   yds: string
   french: string
   band: 'beginner' | 'intermediate' | 'elite' | 'experienced'
+}
+
+export const scales: Record<typeof GradeScales[keyof typeof GradeScales], GradeScale | null> = {
+  [GradeScales.VSCALE]: VScale,
+  [GradeScales.YDS]: YosemiteDecimal,
+  [GradeScales.FONT]: Font,
+  [GradeScales.FRENCH]: French
 }

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import boulder from '../data/boulder.json'
 import { Boulder } from '.'
-export type VScaleType = 'vScale'
+import { boulderScoreToBand } from '../GradeParser'
 
 const vGradeRegex = /^(V[0-9]{1,2})([/+])?([/-])?([0-9]{1,2})?$/i
 const vGradeIrregular = /^V-([a-zA-Z]*)$/i
@@ -23,7 +23,8 @@ const VScale: GradeScale = {
     const parse = grade.match(vGradeRegex)
     if (parse == null) {
       // not a valid V scale
-      return 0
+      console.warn(`Unexpected grade format: ${grade}`)
+      return -1
     }
     const [wholeMatch, basicGrade, plus, dash, secondGrade] = parse
 
@@ -65,7 +66,8 @@ const VScale: GradeScale = {
     const high: string = boulder[validateScore(score[1])].v
     if (low === high) return low
     return `${low}-${high}`
-  }
+  },
+  getGradeBand: (score: number): string => boulderScoreToBand(score)
 }
 
 export default VScale

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -76,7 +76,7 @@ const getScore = (grade: string): number | Tuple => {
   const parse = grade.match(vGradeRegex)
   if (parse == null) {
     // not a valid V scale
-    console.warn(`Unexpected grade format: ${grade}`)
+    console.warn(`Unexpected grade format: ${grade} for grade scale v scale`)
     return -1
   }
   const [wholeMatch, basicGrade, plus, dash, secondGrade] = parse

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import boulder from '../data/boulder.json'
 import { Boulder } from '.'
-import { boulderScoreToBand } from '../GradeBands'
+import { boulderScoreToBand, GradeBandTypes } from '../GradeBands'
 
 const vGradeRegex = /^(V[0-9]{1,2})([/+])?([/-])?([0-9]{1,2})?$/i
 const vGradeIrregular = /^V-([a-zA-Z]*)$/i
@@ -37,7 +37,7 @@ const VScale: GradeScale = {
     if (low === high) return low
     return `${low}-${high}`
   },
-  getGradeBand: (grade: string): string => {
+  getGradeBand: (grade: string): GradeBandTypes => {
     const score = getScore(grade)
     return boulderScoreToBand(getAvgScore(score))
   }

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -8,9 +8,9 @@ const vGradeIrregular = /^V-([a-zA-Z]*)$/i
 
 const VScale: GradeScale = {
   displayName: 'V Scale',
-  name: GradeScales.VScale,
+  name: GradeScales.VSCALE,
   offset: 1000,
-  allowableConversionType: [GradeScales.Font],
+  allowableConversionType: [GradeScales.FONT],
   isType: (grade: string): boolean => {
     const isVGrade = grade.match(vGradeRegex) !== null || grade.match(vGradeIrregular)
     // If there isn't a match sort it to the bottom

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -1,8 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
-
-export type YdsType = 'yds'
+import { routeScoreToBand } from '../GradeParser'
 
 const REGEX_5_X = /(^5\.([0-9]|1[0-6]))()([+-])?$/i
 // Support 5.0 to 5.16 with + and -
@@ -32,7 +31,7 @@ const YosemiteDecimal: GradeScale = {
     const parse = isYds(grade)
     if (parse === null) {
       console.warn(`Unexpected grade format: ${grade}`)
-      return 0
+      return -1
     }
     const [wholeMatch, basicGrade, number, letter, plusOrMinusOrSlash] = parse
     let normalizedGrade = basicGrade
@@ -89,7 +88,8 @@ const YosemiteDecimal: GradeScale = {
       return `${low}/${high}`
     }
     return `${lowBasicGrade}${lowLetter}/${highLetter}`
-  }
+  },
+  getGradeBand: (score: number): string => routeScoreToBand(score)
 }
 
 export default YosemiteDecimal

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
-import { routeScoreToBand } from '../GradeBands'
+import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
 
 const REGEX_5_X = /(^5\.([0-9]|1[0-6]))()([+-])?$/i
 // Support 5.0 to 5.16 with + and -
@@ -52,7 +52,7 @@ const YosemiteDecimal: GradeScale = {
     }
     return `${lowBasicGrade}${lowLetter}/${highLetter}`
   },
-  getGradeBand: (grade: string): string => {
+  getGradeBand: (grade: string): GradeBandTypes => {
     const score = getScore(grade)
     return routeScoreToBand(getAvgScore(score))
   }

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -1,7 +1,7 @@
 import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
-import { routeScoreToBand } from '../GradeParser'
+import { routeScoreToBand } from '../GradeBands'
 
 const REGEX_5_X = /(^5\.([0-9]|1[0-6]))()([+-])?$/i
 // Support 5.0 to 5.16 with + and -
@@ -28,44 +28,7 @@ const YosemiteDecimal: GradeScale = {
   },
 
   getScore: (grade: string): number | Tuple => {
-    const parse = isYds(grade)
-    if (parse === null) {
-      console.warn(`Unexpected grade format: ${grade}`)
-      return -1
-    }
-    const [wholeMatch, basicGrade, number, letter, plusOrMinusOrSlash] = parse
-    let normalizedGrade = basicGrade
-    const plusSlash = ['+', '/'].includes(plusOrMinusOrSlash)
-    const minus = plusOrMinusOrSlash === '-'
-    let normalizedLetter = letter
-    const isLargeNonLetter = parseInt(number, 10) > 9 && normalizedLetter === ''
-    if (isLargeNonLetter) {
-      // 11-, 13+, 12
-      normalizedLetter = minus ? 'a' : plusSlash ? 'c' : 'b'
-    }
-    normalizedGrade = basicGrade + normalizedLetter
-    const basicScore = findScoreRange((r: Route) => {
-      return r.yds === normalizedGrade
-    }, routes)
-
-    if (wholeMatch !== normalizedGrade) {
-      let otherGrade
-      // 5.11+, 5.10a/b
-      if (plusSlash || isLargeNonLetter) {
-        otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[1]) + 1
-      } else if (minus) {
-        // 5.11-
-        otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[0]) - 1
-      }
-
-      if (otherGrade !== undefined) {
-        const nextGrade = findScoreRange((r: Route) => {
-          return r.yds.toLowerCase() === routes[Math.max(otherGrade, 0)].yds.toLowerCase()
-        }, routes)
-        return [getAvgScore(basicScore), getAvgScore(nextGrade)].sort((a, b) => a - b) as Tuple
-      }
-    }
-    return basicScore
+    return getScore(grade)
   },
   getGrade: (score: number | Tuple): string => {
     function validateScore (score: number): number {
@@ -89,7 +52,51 @@ const YosemiteDecimal: GradeScale = {
     }
     return `${lowBasicGrade}${lowLetter}/${highLetter}`
   },
-  getGradeBand: (score: number): string => routeScoreToBand(score)
+  getGradeBand: (grade: string): string => {
+    const score = getScore(grade)
+    return routeScoreToBand(getAvgScore(score))
+  }
+}
+
+const getScore = (grade: string): number | Tuple => {
+  const parse = isYds(grade)
+  if (parse === null) {
+    console.warn(`Unexpected grade format: ${grade}`)
+    return -1
+  }
+  const [wholeMatch, basicGrade, number, letter, plusOrMinusOrSlash] = parse
+  let normalizedGrade = basicGrade
+  const plusSlash = ['+', '/'].includes(plusOrMinusOrSlash)
+  const minus = plusOrMinusOrSlash === '-'
+  let normalizedLetter = letter
+  const isLargeNonLetter = parseInt(number, 10) > 9 && normalizedLetter === ''
+  if (isLargeNonLetter) {
+    // 11-, 13+, 12
+    normalizedLetter = minus ? 'a' : plusSlash ? 'c' : 'b'
+  }
+  normalizedGrade = basicGrade + normalizedLetter
+  const basicScore = findScoreRange((r: Route) => {
+    return r.yds === normalizedGrade
+  }, routes)
+
+  if (wholeMatch !== normalizedGrade) {
+    let otherGrade
+    // 5.11+, 5.10a/b
+    if (plusSlash || isLargeNonLetter) {
+      otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[1]) + 1
+    } else if (minus) {
+      // 5.11-
+      otherGrade = (typeof basicScore === 'number' ? basicScore : basicScore[0]) - 1
+    }
+
+    if (otherGrade !== undefined) {
+      const nextGrade = findScoreRange((r: Route) => {
+        return r.yds.toLowerCase() === routes[Math.max(otherGrade, 0)].yds.toLowerCase()
+      }, routes)
+      return [getAvgScore(basicScore), getAvgScore(nextGrade)].sort((a, b) => a - b) as Tuple
+    }
+  }
+  return basicScore
 }
 
 export default YosemiteDecimal

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -17,9 +17,9 @@ const isYds = (grade: string): RegExpMatchArray | null =>
 
 const YosemiteDecimal: GradeScale = {
   displayName: 'Yosemite Decimal System',
-  name: GradeScales.Yds,
+  name: GradeScales.YDS,
   offset: 1000,
-  allowableConversionType: [GradeScales.French],
+  allowableConversionType: [GradeScales.FRENCH],
   isType: (grade: string): boolean => {
     if (isYds(grade) === null) {
       return false

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -61,7 +61,7 @@ const YosemiteDecimal: GradeScale = {
 const getScore = (grade: string): number | Tuple => {
   const parse = isYds(grade)
   if (parse === null) {
-    console.warn(`Unexpected grade format: ${grade}`)
+    console.warn(`Unexpected grade format: ${grade} for grade scale yds`)
     return -1
   }
   const [wholeMatch, basicGrade, number, letter, plusOrMinusOrSlash] = parse


### PR DESCRIPTION
Fix for https://github.com/OpenBeta/openbeta-graphql/issues/168

Moves GradeBand logic into this repository rather than in the openbeta-graphql repository.
Moves GradeScales logic into this repository rather than in the openbeta-graphql repository.

There are two other PR's connected to this PR:
- https://github.com/OpenBeta/openbeta-graphql/pull/174
- https://github.com/OpenBeta/open-tacos/pull/568