### PR TITLE
Add exports and show sample usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,83 @@ Using Yarn
 yarn add @openbeta/sandbag
 ```
 
-#### Compare YDS grades
+#### Sample Usage
+
+- Convert Grades to Scores
+
 ```javascript
-import { YosemiteDecimal } from '@openbeta/sandbag'
+import { French, YosemiteDecimal } from '@openbeta/sandbag'
 
-const easier = YosemiteDecimal.getScoreForSort('5.6')
-const harder = YosemiteDecimal.getScoreForSort('5.10')
+const score = French.getScore('8a') // Output [ 84, 85 ]
 
-console.log('Is 5.6 easier than 5.10?', easier < harder)  // Output: true
+// Support slash grade
+const slashGradeScore=French.getScore('7c+/8a') // Output [ 82.5, 84.5 ]
+
+// Accept +/- modifier
+const plusGrade= YosemiteDecimal.getScore('5.12+') // Output [ 78.5, 80.5 ]
 ```
+
+- Convert Scores to Grades
+
+```javascript
+import { Font } from '@openbeta/sandbag'
+
+// Single score provided
+Font.getGrade(80) // Output '7c'
+
+// Support a range of scores 
+Font.getGrade([79,81]) // Output'7b+/7c'
+
+```
+
+- Validate Grading Scales
+``` javascript
+import { VScale , Font }from '@openbeta/sandbag'
+
+console.log('Is 6A a V Scale?',VScale.isType('6A'))  // Output false
+console.log('Is 6A a Font Scale?',Font.isType('6A')) // Output true
+
+```
+
+- Convert Grades Across Scales
+
+``` javascript
+import {convertGrade , GradeScales }from '@openbeta/sandbag'
+
+const ydsInFrench=convertGrade('5.11a',GradeScales.YDS,GradeScales.FRENCH) // Output '6b+/6c'
+
+const fontInVScale=convertGrade('6a',GradeScales.FONT,GradeScales.VSCALE) //OutPut 'V3'
+
+// Conversions across different disciplines are not allowed
+const sportToBoulder=convertGrade('5.11a',GradeScales.YDS,GradeScales.VSCALE)
+// Output: Scale: Yosemite Decimal System doesn't support converting to Scale: V Scale
+// ''
+```
+
+- Get Gradeband
+
+```javascript
+import { Ewbank } from '@openbeta/sandbag'
+
+Ewbank.getGradeBand('10') // Output: 'beginner'
+Ewbank.getGradeBand('30') // Output: 'expert'
+Ewbank.getGradeBand('6a') // Output: Unexpected grade format: 6a for grade scale Ewbank 'unknown'
+
+```
+- Compare Grades
+
+```javascript
+
+import { French, YosemiteDecimal } from '@openbeta/sandbag'
+
+const harder = French.getScore('8a')  // Output: [ 84, 85 ]
+const easier = YosemiteDecimal.getScore('5.13a') // Output: [ 82, 83 ]
+
+console.log('Is 8a harder than 5.13a?',harder > easier) // Output: true
+
+```
+
+
 
 See [unit tests](./src/__tests__) for more examples.
 

--- a/src/__tests__/readme.ts
+++ b/src/__tests__/readme.ts
@@ -1,0 +1,81 @@
+import {
+  French,
+  YosemiteDecimal,
+  Font,
+  VScale,
+  GradeScales,
+  convertGrade,
+  Ewbank
+} from '../index'
+
+describe('Convert grades to scores', () => {
+  test('returns the correct score', () => {
+    expect(French.getScore('8a')).toEqual([84, 85])
+    expect(French.getScore('7c+/8a')).toEqual([82.5, 84.5])
+    expect(YosemiteDecimal.getScore('5.12+')).toEqual([78.5, 80.5])
+  })
+})
+
+describe('Convert scores to greades', () => {
+  test('supports single score', () => {
+    expect(Font.getGrade(80)).toEqual('7c')
+  })
+  test('supports a range of scores', () => {
+    expect(Font.getGrade([79, 81])).toEqual('7b+/7c')
+  })
+})
+
+describe('Validate grading scales', () => {
+  test('6A is Font scale not VScale', () => {
+    expect(VScale.isType('6A')).toBe(false)
+    expect(Font.isType('6A')).toBe(true)
+  })
+})
+
+describe('Convert grades across scales', () => {
+  jest.spyOn(console, 'warn').mockImplementation()
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('5.11a YDS is 6b+/6c in Frence', () => {
+    expect(convertGrade('5.11a', GradeScales.YDS, GradeScales.FRENCH)).toEqual(
+      '6b+/6c'
+    )
+  })
+  test('6a Font is V3', () => {
+    expect(convertGrade('6a', GradeScales.FONT, GradeScales.VSCALE)).toEqual(
+      'V3'
+    )
+  })
+  test('Convert from yds to vscale is not allowed', () => {
+    expect(convertGrade('5.11a', GradeScales.YDS, GradeScales.VSCALE)).toEqual(
+      ''
+    )
+    expect(console.warn).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Scale: Yosemite Decimal System doesn't support converting to Scale: V Scale"
+      )
+    )
+  })
+})
+
+describe('Get gradeband', () => {
+  test('returns correct grade band', () => {
+    expect(Ewbank.getGradeBand('10')).toEqual('beginner')
+    expect(Ewbank.getGradeBand('30')).toEqual('expert')
+  })
+  test('pass invalid grade format returns unknown', () => {
+    expect(Ewbank.getGradeBand('6a')).toEqual('unknown')
+  })
+})
+
+describe('Compare grades', () => {
+  const harder = French.getScore('8a') // Output: [ 84, 85 ]
+  const easier = YosemiteDecimal.getScore('5.13a') // Output: [ 82, 83 ]
+  test('returns correct score', () => {
+    expect(harder).toEqual([84, 85])
+    expect(easier).toEqual([82, 83])
+    expect(harder > easier).toBe(true)
+  })
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,15 @@
 
 import { GradeScales, GradeScalesTypes } from './GradeScale'
-import { getScale, getScore, getScoreForSort, isVScale } from './GradeParser'
+import {
+  getScale,
+  getScore,
+  getScoreForSort,
+  isVScale,
+  convertGrade
+} from './GradeParser'
 import { GradeBands, GradeBandTypes } from './GradeBands'
+import { YosemiteDecimal, French, UIAA, Font, VScale, Ewbank } from './scales'
+
 // Free Climbing Grades
 // YDS
 // French
@@ -17,14 +25,40 @@ import { GradeBands, GradeBandTypes } from './GradeBands'
 // Kurtyka (Poland)
 
 const YDS_ARRAY = [
-  '5.0', '5.1', '5.2', '5.3', '5.4',
-  '5.5', '5.6', '5.7', '5.8', '5.9',
-  '5.10a', '5.10b', '5.10c', '5.10d',
-  '5.11a', '5.11b', '5.11c', '5.11d',
-  '5.12a', '5.12b', '5.12c', '5.12d',
-  '5.13a', '5.13b', '5.13c', '5.13d',
-  '5.14a', '5.14b', '5.14c', '5.14d',
-  '5.15a', '5.15b', '5.15c', '5.15d'
+  '5.0',
+  '5.1',
+  '5.2',
+  '5.3',
+  '5.4',
+  '5.5',
+  '5.6',
+  '5.7',
+  '5.8',
+  '5.9',
+  '5.10a',
+  '5.10b',
+  '5.10c',
+  '5.10d',
+  '5.11a',
+  '5.11b',
+  '5.11c',
+  '5.11d',
+  '5.12a',
+  '5.12b',
+  '5.12c',
+  '5.12d',
+  '5.13a',
+  '5.13b',
+  '5.13c',
+  '5.13d',
+  '5.14a',
+  '5.14b',
+  '5.14c',
+  '5.14d',
+  '5.15a',
+  '5.15b',
+  '5.15c',
+  '5.15d'
 ]
 
 const SAXON_ARRAY = [
@@ -35,52 +69,163 @@ const SAXON_ARRAY = [
 ]
 
 const BRITISH_TECH_ARRAY = [
-  '1', '2', '3', '4a', '4b', '4c',
-  '5a', '5b', '5c', '6a', '6b', '6c', '7a',
+  '1',
+  '2',
+  '3',
+  '4a',
+  '4b',
+  '4c',
+  '5a',
+  '5b',
+  '5c',
+  '6a',
+  '6b',
+  '6c',
+  '7a',
   '7b'
 ]
 
 const BRITISH_ADJ_ARRAY = [
-  'M', 'D', 'VD', 'S', 'HS', 'HVS',
-  'E1', 'E2', 'E3', 'E4', 'E5', 'E6',
-  'E7', 'E8', 'E9', 'E10', 'E11'
+  'M',
+  'D',
+  'VD',
+  'S',
+  'HS',
+  'HVS',
+  'E1',
+  'E2',
+  'E3',
+  'E4',
+  'E5',
+  'E6',
+  'E7',
+  'E8',
+  'E9',
+  'E10',
+  'E11'
 ]
 
 const FRENCH_ARRAY = [
-  '1a', '1b', '1c',
-  '2a', '2b', '2c',
-  '3a', '3b', '3c',
-  '4a', '4b', '4c',
-  '5a', '5a+', '5b', '5b+', '5c', '5c+',
-  '6a', '6a+', '6b', '6b+', '6c', '6c+', '7a', '7a+', '7b',
-  '7b+', '7c', '7c+', '8a', '8a+', '8b', '8b+', '8c', '8c+',
-  '9a', '9a+', '9b', '9b+', '9c', '9c+'
+  '1a',
+  '1b',
+  '1c',
+  '2a',
+  '2b',
+  '2c',
+  '3a',
+  '3b',
+  '3c',
+  '4a',
+  '4b',
+  '4c',
+  '5a',
+  '5a+',
+  '5b',
+  '5b+',
+  '5c',
+  '5c+',
+  '6a',
+  '6a+',
+  '6b',
+  '6b+',
+  '6c',
+  '6c+',
+  '7a',
+  '7a+',
+  '7b',
+  '7b+',
+  '7c',
+  '7c+',
+  '8a',
+  '8a+',
+  '8b',
+  '8b+',
+  '8c',
+  '8c+',
+  '9a',
+  '9a+',
+  '9b',
+  '9b+',
+  '9c',
+  '9c+'
 ]
 
 const UIAA_ARRAY = [
-  '1', '2', '3', '4',
-  '4+/5-', '5', '5+', '6-',
-  '6', '6+', '7-', '7', '7+',
-  '8-', '8', '8+', '9-', '9',
-  '9+', '10-', '10', '10+', '11-', '11', '11+',
-  '12-', '12'
+  '1',
+  '2',
+  '3',
+  '4',
+  '4+/5-',
+  '5',
+  '5+',
+  '6-',
+  '6',
+  '6+',
+  '7-',
+  '7',
+  '7+',
+  '8-',
+  '8',
+  '8+',
+  '9-',
+  '9',
+  '9+',
+  '10-',
+  '10',
+  '10+',
+  '11-',
+  '11',
+  '11+',
+  '12-',
+  '12'
 ]
 
 const EWBANK_ARRAY = [
-  '1', '2', '3', '4', '5', '6', '7', '8', '9',
-  '10', '11', '12', '13', '14', '15', '16', '17', '18', '19',
-  '20', '21', '22', '23', '24', '25', '26', '27', '28', '29',
-  '30', '31', '32', '33', '34', '35', '36', '37', '38', '39',
+  '1',
+  '2',
+  '3',
+  '4',
+  '5',
+  '6',
+  '7',
+  '8',
+  '9',
+  '10',
+  '11',
+  '12',
+  '13',
+  '14',
+  '15',
+  '16',
+  '17',
+  '18',
+  '19',
+  '20',
+  '21',
+  '22',
+  '23',
+  '24',
+  '25',
+  '26',
+  '27',
+  '28',
+  '29',
+  '30',
+  '31',
+  '32',
+  '33',
+  '34',
+  '35',
+  '36',
+  '37',
+  '38',
+  '39',
   '40'
 ]
 
-const CLASS_ARRAY = [
-  'Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5'
-]
+const CLASS_ARRAY = ['Class 1', 'Class 2', 'Class 3', 'Class 4', 'Class 5']
 
-export const protection = [
-  'G', 'PG', 'PG13', 'R', 'X'
-]
+export const protection = ['G', 'PG', 'PG13', 'R', 'X']
 
 // Bouldering
 // Hueco
@@ -98,13 +243,26 @@ export const freeClimbing = {
     Ewbank: EWBANK_ARRAY,
     Saxon: SAXON_ARRAY
   },
-  community: {
-
-  }
+  community: {}
 }
 
-export const bouldering = {
+export const bouldering = {}
 
+export { convertGrade }
+
+export {
+  getScore,
+  getScoreForSort,
+  isVScale,
+  getScale,
+  GradeScales,
+  GradeScalesTypes,
+  GradeBands,
+  GradeBandTypes,
+  YosemiteDecimal,
+  French,
+  UIAA,
+  Font,
+  VScale,
+  Ewbank
 }
-
-export { getScore, getScoreForSort, isVScale, getScale, GradeScales, GradeScalesTypes, GradeBands, GradeBandTypes }


### PR DESCRIPTION
I was thinking, for the `convertGrade` function, maybe we should use uppercase to keep the naming consistent. What do you think? @musoke 