### PR TITLE
ci: Run tests on develop

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,9 @@
 name: 'tests'
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches: [develop]
 
 jobs:
   build:


### PR DESCRIPTION
CI isn't testing PRs after they are merged.  This is usually safe, but there is some possibility of tests working on the develop and feature branches separately, but not after merging.