### PR TITLE
fix: add exports field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,14 @@
   "version": "0.0.43",
   "description": "Rock climbing grades and conversions",
   "repository": "https://github.com/OpenBeta/sandbag.git",
-  "module": "dist/sandbag.esm.js",
-  "main": "dist/index.js",
+  "module": "./dist/sandbag.esm.js",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+        "import": "./dist/sandbag.esm.js",
+        "require": "./dist/index.js"
+    }
+  },
   "types": "dist/index.d.ts",
   "scripts": {
     "prepare": "husky install",
@@ -25,7 +31,7 @@
     "ts-node": "^10.6.0",
     "ts-standard": "^12.0.0",
     "tsdx": "^0.14.1",
-    "typescript": "^4.5.5"
+    "typescript": "^4.9.5"
   },
   "engines": {
     "node": ">=14"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8375,9 +8375,9 @@ typescript@^3.7.3:
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
 typescript@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
e4fbbd097cdd066211174737ed51104e1ca40258 added `"typde": "module"` to `package.json`.  This broke importing of sandbag in openbeta-graphql.

package.json also needs an exports field, telling it which modules are exposed for export.  Add it.

Also update to typescript ^4.9.5, a version which supports `package.json` exports.  See
https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing

Fixes https://github.com/OpenBeta/sandbag/issues/123