### PR TITLE
Add test coverage report to README.md and Github actions

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,11 @@
+name: "coverage"
+on:
+  pull_request_target:
+    branches:
+      - develop
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ArtiomTr/jest-coverage-report-action@v2

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 yarn lint
-yarn test
+yarn test --coverage
 yarn build

--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ yarn install
 yarn test
 ```
 
+#### Generating Test Coverage Report
+
+To generate a test coverage report using Jest run the following command in your terminal:
+
+```sh
+npx jest --coverage
+```
+
+If you're using macOS, you can directly access the coverage report in your browser by opening the following URL:
+
+```
+file:///Users/<userName>/sandbag/coverage/lcov-report/index.html
+```
+
 #### How to publish a new release to NPM
 Submit a PR with commit message `[npm publish]`
 

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,13 @@
 /** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
 module.exports = {
   preset: 'ts-jest',
-  testEnvironment: 'node'
+  testEnvironment: 'node',
+  coverageThreshold: {
+    global: {
+      branches: 20,
+      functions: 20,
+      lines: 20,
+      statements: -999999 // Exceptionally high allowance for uncovered statements to start
+    }
+  }
 }


### PR DESCRIPTION
I moved my work from my fork's `develop` branch into a `feature` branch and when I force-pushed it closed [my old PR ](https://github.com/OpenBeta/sandbag/pull/151) automatically (I've gotten used to BitBucket).