### PR TITLE
test: Improve coverage for Saxon Scales.

### DIFF
--- a/src/scales/__tests__/saxon.ts
+++ b/src/scales/__tests__/saxon.ts
@@ -40,4 +40,11 @@ describe('SAXON', () => {
       expect(isValid).toBe(false)
     })
   })
+
+  describe('getScore', () => {
+    test('should handle grade format with slash "7a/7b"', () => {
+      const score = SaxonScale.getScore('7a/7b')
+      expect(score).not.toEqual(-1)
+    })
+  })
 })

--- a/src/scales/__tests__/saxon.ts
+++ b/src/scales/__tests__/saxon.ts
@@ -1,0 +1,43 @@
+import { Saxon as SaxonScale } from '../../scales'
+
+describe('SAXON', () => {
+  describe('valid grade formats', () => {
+    let consoleWarnSpy
+
+    beforeEach(() => {
+      consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation()
+    })
+
+    afterEach(() => {
+      consoleWarnSpy.mockRestore()
+    })
+
+    test('should handle valid grade format "1"', () => {
+      const score = SaxonScale.getScore('1')
+      expect(console.warn).not.toHaveBeenCalled()
+      expect(score).not.toEqual(-1)
+    })
+  })
+
+  describe('isType', () => {
+    test('should return true for valid grade format "7a"', () => {
+      const isValid = SaxonScale.isType('7a')
+      expect(isValid).toBe(true)
+    })
+
+    test('should return true for valid grade format "1"', () => {
+      const isValid = SaxonScale.isType('1')
+      expect(isValid).toBe(true)
+    })
+
+    test('should return false for invalid grade format "V"', () => {
+      const isValid = SaxonScale.isType('V')
+      expect(isValid).toBe(false)
+    })
+
+    test('should return false for invalid grade format "8d"', () => {
+      const isValid = SaxonScale.isType('8d')
+      expect(isValid).toBe(false)
+    })
+  })
+})

--- a/src/scales/saxon.ts
+++ b/src/scales/saxon.ts
@@ -3,7 +3,7 @@ import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
 
-const saxonGradeRegex = /^((([7-9]|1[0-3])([a-c]))|([1-6]))$/i
+const saxonGradeRegex = /^((([7-9]|1[0-3])([a-c]))|([1-6])|([7-9]|1[0-3])(([a-c])\/([7-9]|1[0-3])([a-c])))$/i
 // Saxon grading system, predominant in Central Europe (esp. Germany, Austria, Switzerland)
 // Supports 1 -> 13c, slash grades i.e. 7a/7b
 // Uses Arabic numerals with letters from a-c, e.g. "7a" , "7b", or "7c" (hardest)


### PR DESCRIPTION
I was trying to make a test for '7a/7b' but it was erroring that it was not an expected Saxon Grade. I believe this is a problem with the regex in `src/scales/saxon.ts`. From some simple testing, this regex matches '7a/7b': `1/^((([7-9]|1[0-3])([a-c]))|([1-6])|([7-9]|1[0-3])(([a-c])\/([7-9]|1[0-3])([a-c])))$/i`.

For now I pushed up tests that pass inside one commit. For the sake of performance, they were specifically written to improve coverage and nothing else (i.e. `__tests__/saxon.ts` is not a comprehensive test suite for the Saxon system).

The other commit includes a potential solution to the grade regex. 