### PR TITLE
feat: infer GradeScale from grade

### DIFF
--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -67,6 +67,14 @@ export const convertGrade = (
   return toScale.getGrade(toScore)
 }
 
+export const inferScale = (grade: string): GradeScalesTypes | null => {
+  const matchedScales = Object.values(scales)
+    .map(scale => [scale.name, scale.isType(grade)] as const)
+    .filter(v => v[1])
+  if (matchedScales.length === 1) return matchedScales[0][0]
+  return null
+}
+
 export const isVScale = (grade: string): boolean => {
   const scale = scales[GradeScales.VSCALE]
   if (scale == null) {

--- a/src/__tests__/GradeParser.ts
+++ b/src/__tests__/GradeParser.ts
@@ -1,4 +1,4 @@
-import { getScoreForSort, convertGrade, getScale } from '../GradeParser'
+import { getScoreForSort, convertGrade, getScale, inferScale } from '../GradeParser'
 import { GradeScales } from '../GradeScale'
 import { VScale, Font, YosemiteDecimal, French, Saxon, AI, WI } from '../scales'
 
@@ -320,6 +320,17 @@ describe('Grade Scales', () => {
           "Scale: WI Grade doesn't support converting to Scale: French"
         )
       )
+    })
+  })
+
+  describe('inferScale', () => {
+    test.each([
+      [GradeScales.YDS, '5.10'],
+      [null, '6a'],
+      [null, 'abcdef'],
+      [GradeScales.VSCALE, 'V7']
+    ])('detects %s scale for %s', (scale, grade) => {
+      expect(inferScale(grade)).toEqual(scale)
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {
   getScale,
   getScore,
   getScoreForSort,
+  inferScale,
   isVScale,
   convertGrade
 } from './GradeParser'
@@ -294,6 +295,7 @@ export {
   getScoreForSort,
   isVScale,
   getScale,
+  inferScale,
   GradeScales,
   GradeScalesTypes,
   GradeBands,

--- a/src/scales/index.ts
+++ b/src/scales/index.ts
@@ -9,7 +9,7 @@ import AI from './ai'
 import Aid from './aid'
 import WI from './wi'
 import UIAA from './uiaa'
-import GradeScale, { GradeScales } from '../GradeScale'
+import { GradeScales } from '../GradeScale'
 export { Aid, VScale, Font, YosemiteDecimal, French, Saxon, UIAA, Ewbank, AI, WI, Norwegian }
 
 export interface Boulder {
@@ -39,10 +39,7 @@ export interface AidGrade {
   aid: string
 }
 
-export const scales: Record<
-  typeof GradeScales[keyof typeof GradeScales],
-GradeScale | null
-> = {
+export const scales = {
   [GradeScales.VSCALE]: VScale,
   [GradeScales.YDS]: YosemiteDecimal,
   [GradeScales.FONT]: Font,
@@ -54,4 +51,4 @@ GradeScale | null
   [GradeScales.AI]: AI,
   [GradeScales.WI]: WI,
   [GradeScales.AID]: Aid
-}
+} as const


### PR DESCRIPTION
Lets TypeScript detect each GradeScale's exact `name`, `offset`, `allowableConversionType`.

https://github.com/OpenBeta/sandbag/issues/94