### PR TITLE
Replace allowableConversionType with conversionGroup

### DIFF
--- a/src/GradeParser.ts
+++ b/src/GradeParser.ts
@@ -56,8 +56,8 @@ export const convertGrade = (
   if (fromScale === null || toScale === null) {
     return ''
   }
-  const checkScaleToConvert: boolean = fromScale.allowableConversionType.includes(toGradeScaleType)
-  if (!checkScaleToConvert) {
+  const sameConversionGroup: boolean = fromScale.conversionGroup === toScale.conversionGroup
+  if (!sameConversionGroup) {
     console.warn(
       `Scale: ${fromScale.displayName} doesn't support converting to Scale: ${toScale.displayName}`
     )

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -10,7 +10,7 @@ export default interface GradeScale {
   displayName: string
   name: GradeScalesTypes
   offset: number
-  conversionGroup: string
+  conversionGroup: ConversionGroupsTypes
   grades?: string[]
 }
 
@@ -30,6 +30,15 @@ export const GradeScales = {
 } as const
 
 export type GradeScalesTypes = typeof GradeScales[keyof typeof GradeScales]
+
+export const ConversionGroups = {
+  AID: 'aid',
+  FREE: 'free',
+  BOULDERING: 'bouldering',
+  ICE: 'ice'
+} as const
+
+export type ConversionGroupsTypes = typeof ConversionGroups[keyof typeof ConversionGroups]
 
 export const findScoreRange = (compareFn, list): number | Tuple => {
   const scores = list.filter(compareFn)

--- a/src/GradeScale.ts
+++ b/src/GradeScale.ts
@@ -10,7 +10,7 @@ export default interface GradeScale {
   displayName: string
   name: GradeScalesTypes
   offset: number
-  allowableConversionType: GradeScalesTypes[]
+  conversionGroup: string
   grades?: string[]
 }
 

--- a/src/scales/ai.ts
+++ b/src/scales/ai.ts
@@ -13,7 +13,7 @@ const AIScale: GradeScale = {
   displayName: 'AI Grade',
   name: GradeScales.AI,
   offset: 1000,
-  allowableConversionType: [GradeScales.WI],
+  conversionGroup: 'Ice',
   isType: (grade: string): boolean => {
     if (isAI(grade) === null) {
       return false

--- a/src/scales/ai.ts
+++ b/src/scales/ai.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple } from '../GradeScale'
 import ice_table from '../data/ice.json'
 import { IceGrade } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -13,7 +13,7 @@ const AIScale: GradeScale = {
   displayName: 'AI Grade',
   name: GradeScales.AI,
   offset: 1000,
-  conversionGroup: 'Ice',
+  conversionGroup: ConversionGroups.ICE,
   isType: (grade: string): boolean => {
     if (isAI(grade) === null) {
       return false

--- a/src/scales/aid.ts
+++ b/src/scales/aid.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple } from '../GradeScale'
 import aid_table from '../data/aid.json'
 import { AidGrade } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -12,7 +12,7 @@ const AidScale: GradeScale = {
   displayName: 'Aid Grade',
   name: GradeScales.AID,
   offset: 1000,
-  conversionGroup: 'Aid',
+  conversionGroup: ConversionGroups.AID,
   isType: (grade: string): boolean => {
     if (isAid(grade) === null) {
       return false

--- a/src/scales/aid.ts
+++ b/src/scales/aid.ts
@@ -12,7 +12,7 @@ const AidScale: GradeScale = {
   displayName: 'Aid Grade',
   name: GradeScales.AID,
   offset: 1000,
-  allowableConversionType: [],
+  conversionGroup: 'Aid',
   isType: (grade: string): boolean => {
     if (isAid(grade) === null) {
       return false

--- a/src/scales/brazilian.ts
+++ b/src/scales/brazilian.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -71,7 +71,7 @@ const BrazilianCrux: GradeScale = {
   displayName: 'Brazilian Crux Scale',
   name: GradeScales.BRAZILIAN_CRUX,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => isBrazilianCrux(grade) !== null,
   getScore,
   getGrade: (score: number | Tuple): string => {

--- a/src/scales/brazilian.ts
+++ b/src/scales/brazilian.ts
@@ -71,7 +71,7 @@ const BrazilianCrux: GradeScale = {
   displayName: 'Brazilian Crux Scale',
   name: GradeScales.BRAZILIAN_CRUX,
   offset: 1000,
-  allowableConversionType: [GradeScales.YDS, GradeScales.SAXON, GradeScales.EWBANK, GradeScales.FRENCH, GradeScales.NORWEGIAN],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => isBrazilianCrux(grade) !== null,
   getScore,
   getGrade: (score: number | Tuple): string => {

--- a/src/scales/ewbank.ts
+++ b/src/scales/ewbank.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, getRoundedScoreTuple, Tuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, getRoundedScoreTuple, Tuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -15,7 +15,7 @@ const EwbankScale: GradeScale = {
   displayName: 'Ewbank Grade',
   name: GradeScales.EWBANK,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isEwbank(grade) === null) {
       return false

--- a/src/scales/ewbank.ts
+++ b/src/scales/ewbank.ts
@@ -15,7 +15,7 @@ const EwbankScale: GradeScale = {
   displayName: 'Ewbank Grade',
   name: GradeScales.EWBANK,
   offset: 1000,
-  allowableConversionType: [GradeScales.YDS, GradeScales.FRENCH, GradeScales.SAXON],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isEwbank(grade) === null) {
       return false

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -14,7 +14,7 @@ const FontScale: GradeScale = {
   displayName: 'Fontainebleau',
   name: GradeScales.FONT,
   offset: 1000,
-  allowableConversionType: [GradeScales.VSCALE],
+  conversionGroup: 'Bouldering',
   isType: (grade: string): boolean => {
     if (isFont(grade) === null) {
       return false

--- a/src/scales/font.ts
+++ b/src/scales/font.ts
@@ -1,5 +1,5 @@
 import boulder from '../data/boulder.json'
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 
 import { Boulder } from '.'
 import { boulderScoreToBand, GradeBandTypes } from '../GradeBands'
@@ -14,7 +14,7 @@ const FontScale: GradeScale = {
   displayName: 'Fontainebleau',
   name: GradeScales.FONT,
   offset: 1000,
-  conversionGroup: 'Bouldering',
+  conversionGroup: ConversionGroups.BOULDERING,
   isType: (grade: string): boolean => {
     if (isFont(grade) === null) {
       return false

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -13,7 +13,7 @@ const FrenchScale: GradeScale = {
   displayName: 'French Scale',
   name: GradeScales.FRENCH,
   offset: 1000,
-  allowableConversionType: [GradeScales.YDS, GradeScales.EWBANK, GradeScales.SAXON],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isFrench(grade) === null) {
       return false

--- a/src/scales/french.ts
+++ b/src/scales/french.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -13,7 +13,7 @@ const FrenchScale: GradeScale = {
   displayName: 'French Scale',
   name: GradeScales.FRENCH,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isFrench(grade) === null) {
       return false

--- a/src/scales/norwegian.ts
+++ b/src/scales/norwegian.ts
@@ -13,7 +13,7 @@ const Norwegian: GradeScale = {
   displayName: 'Norwegian Scale',
   name: GradeScales.NORWEGIAN,
   offset: 1000,
-  allowableConversionType: [],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isNorwegian(grade) === null) {
       return false

--- a/src/scales/norwegian.ts
+++ b/src/scales/norwegian.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -13,7 +13,7 @@ const Norwegian: GradeScale = {
   displayName: 'Norwegian Scale',
   name: GradeScales.NORWEGIAN,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isNorwegian(grade) === null) {
       return false

--- a/src/scales/saxon.ts
+++ b/src/scales/saxon.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -14,7 +14,7 @@ const SaxonScale: GradeScale = {
   displayName: 'Saxon Scale',
   name: GradeScales.SAXON,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isSaxon(grade) === null) {
       return false

--- a/src/scales/saxon.ts
+++ b/src/scales/saxon.ts
@@ -14,7 +14,7 @@ const SaxonScale: GradeScale = {
   displayName: 'Saxon Scale',
   name: GradeScales.SAXON,
   offset: 1000,
-  allowableConversionType: [GradeScales.YDS, GradeScales.EWBANK, GradeScales.FRENCH],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isSaxon(grade) === null) {
       return false

--- a/src/scales/uiaa.ts
+++ b/src/scales/uiaa.ts
@@ -14,7 +14,7 @@ const UIAAScale: GradeScale = {
   displayName: 'UIAA Scale',
   name: GradeScales.UIAA,
   offset: 2000,
-  allowableConversionType: [GradeScales.YDS, GradeScales.SAXON, GradeScales.EWBANK, GradeScales.FRENCH],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isUIAA(grade) === null) {
       return false

--- a/src/scales/uiaa.ts
+++ b/src/scales/uiaa.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -14,7 +14,7 @@ const UIAAScale: GradeScale = {
   displayName: 'UIAA Scale',
   name: GradeScales.UIAA,
   offset: 2000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isUIAA(grade) === null) {
       return false

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import boulder from '../data/boulder.json'
 import { Boulder } from '.'
 import { boulderScoreToBand, GradeBandTypes } from '../GradeBands'
@@ -9,7 +9,7 @@ const VScale: GradeScale = {
   displayName: 'V Scale',
   name: GradeScales.VSCALE,
   offset: 1000,
-  conversionGroup: 'Bouldering',
+  conversionGroup: ConversionGroups.BOULDERING,
   isType: (grade: string): boolean => {
     const isVGrade = grade.match(vGradeRegex)
     // If there isn't a match sort it to the bottom

--- a/src/scales/v.ts
+++ b/src/scales/v.ts
@@ -9,7 +9,7 @@ const VScale: GradeScale = {
   displayName: 'V Scale',
   name: GradeScales.VSCALE,
   offset: 1000,
-  allowableConversionType: [GradeScales.FONT],
+  conversionGroup: 'Bouldering',
   isType: (grade: string): boolean => {
     const isVGrade = grade.match(vGradeRegex)
     // If there isn't a match sort it to the bottom

--- a/src/scales/wi.ts
+++ b/src/scales/wi.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple } from '../GradeScale'
 import ice_table from '../data/ice.json'
 import { IceGrade } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -13,7 +13,7 @@ const WIScale: GradeScale = {
   displayName: 'WI Grade',
   name: GradeScales.WI,
   offset: 1000,
-  conversionGroup: 'Ice',
+  conversionGroup: ConversionGroups.ICE,
   isType: (grade: string): boolean => {
     if (isWI(grade) === null) {
       return false

--- a/src/scales/wi.ts
+++ b/src/scales/wi.ts
@@ -13,7 +13,7 @@ const WIScale: GradeScale = {
   displayName: 'WI Grade',
   name: GradeScales.WI,
   offset: 1000,
-  allowableConversionType: [GradeScales.AI],
+  conversionGroup: 'Ice',
   isType: (grade: string): boolean => {
     if (isWI(grade) === null) {
       return false

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -1,4 +1,4 @@
-import GradeScale, { findScoreRange, getAvgScore, GradeScales, Tuple, getRoundedScoreTuple } from '../GradeScale'
+import GradeScale, { findScoreRange, getAvgScore, GradeScales, ConversionGroups, Tuple, getRoundedScoreTuple } from '../GradeScale'
 import routes from '../data/routes.json'
 import { Route } from '.'
 import { GradeBandTypes, routeScoreToBand } from '../GradeBands'
@@ -19,7 +19,7 @@ const YosemiteDecimal: GradeScale = {
   displayName: 'Yosemite Decimal System',
   name: GradeScales.YDS,
   offset: 1000,
-  conversionGroup: 'Free',
+  conversionGroup: ConversionGroups.FREE,
   isType: (grade: string): boolean => {
     if (isYds(grade) === null) {
       return false

--- a/src/scales/yds.ts
+++ b/src/scales/yds.ts
@@ -19,7 +19,7 @@ const YosemiteDecimal: GradeScale = {
   displayName: 'Yosemite Decimal System',
   name: GradeScales.YDS,
   offset: 1000,
-  allowableConversionType: [GradeScales.FRENCH, GradeScales.EWBANK, GradeScales.SAXON],
+  conversionGroup: 'Free',
   isType: (grade: string): boolean => {
     if (isYds(grade) === null) {
       return false


### PR DESCRIPTION
This is my attempt to fix #175 

Instead of using allowableCoversionType that required to define for each scale the list of compatible scales I'm proposing to use a simpler group mechanism where a scale is part of a group of compatible scales.
A scale can be converted to any other scale of the same group.

I'm not entirely sure if this assumption is correct. please let me know if this is not the case