### PR TITLE
[npm publish] trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,36 +1,33 @@
 name: NPM publish
 on:
   workflow_call:
-    secrets:
-      NPM_TOKEN:
-        required: true
 jobs:
   build:
     name: 'npm publish'
     runs-on: ubuntu-latest
     environment: production
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: 'Checkout source code'
-        uses: 'actions/checkout@v3'
+        uses: 'actions/checkout@v4'
         with:
           ref: develop
 
       - name: 'Show current version'
         run: grep  '"version"' package.json
 
-      # Setup .npmrc file to publish to npm
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
           always-auth: true
           scope: '@openbeta'
           registry-url: 'https://registry.npmjs.org'
 
-      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+      - name: Update npm
+        run: npm install -g npm@11
 
       - name: NPM publish
-        run: yarn install --no-progress && yarn lint && yarn test && yarn build && yarn publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
+        run: yarn install --no-progress && yarn lint && yarn test && yarn build && npm publish --provenance --access public


### PR DESCRIPTION
use OIDC instead of NPM_TOKEN