### PR TITLE
[npm publish] remove environment from publish job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -32,7 +32,6 @@ jobs:
     needs: version-bump
     if: startsWith(github.event.pull_request.title, '[npm publish]')
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
try without environment to match npm trusted publisher config