### PR TITLE
Add TypeScript definition file to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/sandbag.esm.js",
-      "require": "./dist/index.js"
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
     }
   },
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Currently, when using the 0.0.55 with typescript 7, I get the following error:

```
Could not find a declaration file for module '@openbeta/sandbag'. 'C:/Users/remim/prog/climbhub/node_modules/.bun/@openbeta+sandbag@0.0.55/node_modules/@openbeta/sandbag/dist/sandbag.esm.js' implicitly has an 'any' type.
  There are types at 'C:/Users/remim/prog/climbhub/node_modules/.bun/@openbeta+sandbag@0.0.55/node_modules/@openbeta/sandbag/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@openbeta/sandbag' library may need to update its package.json or typings.ts(7016)
```

It seems that although referenced by the "types" field, they are not exported, so typescript 7 refuses to use them.

Adding "types" to export fixes it.